### PR TITLE
Fix compilation under certain circumstances

### DIFF
--- a/src/KDFoundation/platform/win32/win32_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/win32/win32_platform_event_loop.cpp
@@ -27,7 +27,7 @@ enum {
     WM_KD_SOCKETEVENT = WM_USER,
 };
 
-LRESULT Win32PlatformEventLoop::messageWindowProc(HWND hwnd, UINT msgId, WPARAM wp, LPARAM lp)
+LRESULT CALLBACK Win32PlatformEventLoop::messageWindowProc(HWND hwnd, UINT msgId, WPARAM wp, LPARAM lp)
 {
     auto *loop = reinterpret_cast<Win32PlatformEventLoop *>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
 

--- a/src/KDFoundation/platform/win32/win32_platform_event_loop.h
+++ b/src/KDFoundation/platform/win32/win32_platform_event_loop.h
@@ -56,7 +56,7 @@ private:
     };
     std::unordered_map<int, NotifierSet> m_notifiers;
 
-    static LRESULT messageWindowProc(HWND, UINT, WPARAM, LPARAM);
+    static LRESULT CALLBACK messageWindowProc(HWND, UINT, WPARAM, LPARAM);
     void handleSocketMessage(WPARAM wParam, LPARAM lParam);
     bool registerWithWSAAsyncSelect(int fd, const NotifierSet &notifiers) const;
 

--- a/src/KDGui/platform/win32/win32_platform_window.cpp
+++ b/src/KDGui/platform/win32/win32_platform_window.cpp
@@ -49,7 +49,7 @@ KeyboardModifiers getKeyboardModifiers()
     return modifiers;
 }
 
-LRESULT windowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
     auto *platformWindow = reinterpret_cast<Win32PlatformWindow *>(GetProp(hwnd, KDGuiPlatformWindowProperty));
     if (!platformWindow)


### PR DESCRIPTION
Functions passed as WNDPROC need to have their calling convention defined via CALLBACK define. Normally CALLBACK expands to __stdcall and by default functions are __cdecl which is a mismatch.

Not sure why it worked before.

Change-Id: I1bffcb7b9b4342375c5db631729a8deae357569f