### PR TITLE
Bump KDBindings to 1.0.5

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -73,7 +73,7 @@ if(NOT TARGET KDAB::KDBindings)
     fetchcontent_declare(
         KDBindings
         GIT_REPOSITORY https://github.com/KDAB/KDBindings.git
-        GIT_TAG 8403345d906ab3fcdd063dcab6280fe36f014191 # v1.0.4
+        GIT_TAG e430d8362cdd4de01cd430bdcf63465c52d49765 # v1.0.5
         USES_TERMINAL_DOWNLOAD YES USES_TERMINAL_UPDATE YES
     )
     fetchcontent_makeavailable(KDBindings)


### PR DESCRIPTION
This fixes compilation errors on Windows with COM headers that define the 'interface' keyword.