### PR TITLE
Fix race condition with deferred connections

### DIFF
--- a/src/KDFoundation/platform/abstract_platform_event_loop.h
+++ b/src/KDFoundation/platform/abstract_platform_event_loop.h
@@ -51,9 +51,6 @@ public:
     }
     std::shared_ptr<KDBindings::ConnectionEvaluator> connectionEvaluator()
     {
-        if (!m_connectionEvaluator) {
-            m_connectionEvaluator = std::make_shared<KDBindings::ConnectionEvaluator>();
-        }
         return m_connectionEvaluator;
     }
 
@@ -61,7 +58,7 @@ protected:
     virtual std::unique_ptr<AbstractPlatformTimer> createPlatformTimerImpl(Timer *timer) = 0;
 
     Postman *m_postman{ nullptr };
-    std::shared_ptr<KDBindings::ConnectionEvaluator> m_connectionEvaluator{ nullptr };
+    std::shared_ptr<KDBindings::ConnectionEvaluator> m_connectionEvaluator{ new KDBindings::ConnectionEvaluator };
 };
 
 } // namespace KDFoundation


### PR DESCRIPTION
Lazy creation of ConnectionEvaluator in event loop was not guarded and
it may happen from a secondary thread (or multiple of those as was the
case with tests). This is actually quite probable as the idea behind
deferred connections is that they may be connected to from threads other
than main.

In "Multiple Signals with Evaluator" test two threads tried to do a deferred
connection at the same time and apparently this caused race condition in
creation of the evaluator.

Now we unconditionally create the connection evaluator in the event
loop. This way, we know that the evaluator is fully created by the end
of the event loop construction. Our assumption is that the user shouldn't
use the evaluator from another thread before the loop is fully
constructed.