### PR TITLE
.clang-tidy - remove unsupported option 'AnalyzeTemporaryDtors'

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,*,-google-*,-cppcoreguidelines-*,-readability-else-after-return,-readability-implicit-bool-cast,-llvm-include-order,-readability-named-parameter,-readabilty-namespace-comments,-llvm-namespace-comment,-clang-analyzer-alpha.core.CastToStruct,-modernize-use-override,-modernize-use-bool-literals,-clang-analyzer-cplusplus.NewDeleteLeaks,-clang-analyzer-alpha.deadcode.UnreachableCode,-modernize-use-default,-clang-analyzer-core.CallAndMessage,-modernize-pass-by-value,-clang-analyzer-core.NonNullParamChecker,-modernize-raw-string-literal,-modernize-use-using,-modernize-loop-convert,-modernize-use-emplace,-modernize-return-braced-init-list,-modernize-use-default-member-init,-modernize-use-equals-default,-fuchsia-*,-hicpp-*,-readability-implicit-bool-conversion,-llvm-*,-llvmlibc-*,-modernize-use-trailing-return-type,-readability-magic-numbers,-readability-qualified-auto,-clang-diagnostic-gnu-zero-variadic-macro-arguments,-android-*,-bugprone-suspicious-include,-readability-uppercase-literal-suffix,-readability-braces-around-statements,-readability-identifier-length,-readability-function-cognitive-complexity,-misc-no-recursion,-altera-*,-abseil-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:             cert-oop11-cpp.UseCERTSemantics
     value:           '1'


### PR DESCRIPTION
AnalyzeTemporaryDtors has been deprecated for a long time
