### PR TITLE
Implement auto invocation of deferred slots

### DIFF
--- a/src/KDFoundation/CMakeLists.txt
+++ b/src/KDFoundation/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     object.cpp
     postman.cpp
     timer.cpp
+    platform/abstract_platform_event_loop.cpp
 )
 
 set(HEADERS

--- a/src/KDFoundation/platform/abstract_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/abstract_platform_event_loop.cpp
@@ -1,0 +1,70 @@
+/*
+  This file is part of KDUtils.
+
+  SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  Author: Miłosz Kosobucki <milosz.kosobucki@kdab.com>
+
+  SPDX-License-Identifier: MIT
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include <KDFoundation/platform/abstract_platform_event_loop.h>
+#include "abstract_platform_event_loop.h"
+
+namespace KDFoundation {
+
+/**
+ * KDUtils-specific connection evaluator that wakes up the owning event loop when slot invocation is
+ * enqueued via the loop's connection evaluator.
+ */
+class ConnectionEvaluator final : public KDBindings::ConnectionEvaluator
+{
+public:
+    ConnectionEvaluator(AbstractPlatformEventLoop *eventLoop)
+        : m_eventLoop(eventLoop) { }
+
+    void setEventLoop(AbstractPlatformEventLoop *eventLoop)
+    {
+        this->m_eventLoop = eventLoop;
+    }
+
+protected:
+    void onInvocationAdded() override
+    {
+        if (m_eventLoop) {
+            m_eventLoop->wakeUp();
+        }
+    }
+
+private:
+    AbstractPlatformEventLoop *m_eventLoop = nullptr;
+};
+} // namespace KDFoundation
+
+using namespace KDFoundation;
+
+KDFoundation::AbstractPlatformEventLoop::AbstractPlatformEventLoop()
+    : m_connectionEvaluator(new ConnectionEvaluator(this))
+{
+}
+
+AbstractPlatformEventLoop::~AbstractPlatformEventLoop()
+{
+    // Make sure that any remaining references to our connection evaluator aren't referring to a dead
+    // event loop object.
+    if (m_connectionEvaluator) {
+        std::static_pointer_cast<KDFoundation::ConnectionEvaluator>(m_connectionEvaluator)->setEventLoop(nullptr);
+    }
+}
+
+void KDFoundation::AbstractPlatformEventLoop::waitForEvents(int timeout)
+{
+    waitForEventsImpl(timeout);
+
+    // Possibly we woke up because of deferred slot invocation was posted. Let's (possibly)
+    // execute them while we're at it.
+    if (m_connectionEvaluator) {
+        m_connectionEvaluator->evaluateDeferredConnections();
+    }
+}

--- a/src/KDFoundation/platform/abstract_platform_event_loop.h
+++ b/src/KDFoundation/platform/abstract_platform_event_loop.h
@@ -28,7 +28,8 @@ class Timer;
 class KDFOUNDATION_API AbstractPlatformEventLoop
 {
 public:
-    virtual ~AbstractPlatformEventLoop() { }
+    AbstractPlatformEventLoop();
+    virtual ~AbstractPlatformEventLoop();
 
     void setPostman(Postman *postman) { m_postman = postman; }
     Postman *postman() { return m_postman; }
@@ -37,7 +38,7 @@ public:
     // -1 means wait forever
     // 0 means do not wait (i.e. poll)
     // +ve number, wait for up to timeout msecs
-    virtual void waitForEvents(int timeout) = 0;
+    void waitForEvents(int timeout);
 
     // Kick the event loop out of waiting
     virtual void wakeUp() = 0;
@@ -56,9 +57,10 @@ public:
 
 protected:
     virtual std::unique_ptr<AbstractPlatformTimer> createPlatformTimerImpl(Timer *timer) = 0;
+    virtual void waitForEventsImpl(int timeout) = 0;
 
     Postman *m_postman{ nullptr };
-    std::shared_ptr<KDBindings::ConnectionEvaluator> m_connectionEvaluator{ new KDBindings::ConnectionEvaluator };
+    std::shared_ptr<KDBindings::ConnectionEvaluator> m_connectionEvaluator;
 };
 
 } // namespace KDFoundation

--- a/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
@@ -61,7 +61,7 @@ LinuxPlatformEventLoop::~LinuxPlatformEventLoop()
         SPDLOG_CRITICAL("Failed to cleanup epoll");
 }
 
-void LinuxPlatformEventLoop::waitForEvents(int timeout)
+void LinuxPlatformEventLoop::waitForEventsImpl(int timeout)
 {
     const int maxEventCount = 16;
     epoll_event events[maxEventCount];

--- a/src/KDFoundation/platform/linux/linux_platform_event_loop.h
+++ b/src/KDFoundation/platform/linux/linux_platform_event_loop.h
@@ -35,7 +35,6 @@ public:
     LinuxPlatformEventLoop(LinuxPlatformEventLoop &&other) = delete;
     LinuxPlatformEventLoop &operator=(LinuxPlatformEventLoop &&other) = delete;
 
-    void waitForEvents(int timeout) override;
     void wakeUp() override;
 
     bool registerNotifier(FileDescriptorNotifier *notifier) override;
@@ -51,6 +50,9 @@ public:
     int epollEventFromFdPlusType(int fd, FileDescriptorNotifier::NotificationType type);
     int epollEventFromFdMinusType(int fd, FileDescriptorNotifier::NotificationType type);
     int epollEventFromNotifierTypes(bool read, bool write, bool exception);
+
+protected:
+    void waitForEventsImpl(int timeout) override;
 
 private:
     std::unique_ptr<AbstractPlatformTimer> createPlatformTimerImpl(Timer *timer) override;

--- a/src/KDFoundation/platform/macos/macos_platform_event_loop.h
+++ b/src/KDFoundation/platform/macos/macos_platform_event_loop.h
@@ -27,7 +27,6 @@ public:
     MacOSPlatformEventLoop(MacOSPlatformEventLoop &&other) = delete;
     MacOSPlatformEventLoop &operator=(MacOSPlatformEventLoop &&other) = delete;
 
-    void waitForEvents(int timeout) override;
     void wakeUp() override;
 
     bool registerNotifier(FileDescriptorNotifier *notifier) override;
@@ -36,6 +35,7 @@ public:
     static void postEmptyEvent();
 
 private:
+    void waitForEventsImpl(int timeout) override;
     std::unique_ptr<AbstractPlatformTimer> createPlatformTimerImpl(Timer *timer) override;
 };
 

--- a/src/KDFoundation/platform/macos/macos_platform_event_loop.mm
+++ b/src/KDFoundation/platform/macos/macos_platform_event_loop.mm
@@ -29,7 +29,7 @@ MacOSPlatformEventLoop::MacOSPlatformEventLoop()
 
 MacOSPlatformEventLoop::~MacOSPlatformEventLoop() = default;
 
-void MacOSPlatformEventLoop::waitForEvents(int timeout)
+void MacOSPlatformEventLoop::waitForEventsImpl(int timeout)
 {
     @autoreleasepool {
         NSDate *expiration = [timeout] {

--- a/src/KDFoundation/platform/win32/win32_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/win32/win32_platform_event_loop.cpp
@@ -79,7 +79,7 @@ Win32PlatformEventLoop::~Win32PlatformEventLoop()
         SPDLOG_WARN("Failed to unregister message window class");
 }
 
-void Win32PlatformEventLoop::waitForEvents(int timeout)
+void Win32PlatformEventLoop::waitForEventsImpl(int timeout)
 {
     MSG msg;
     bool hasMessage = PeekMessage(&msg, 0, 0, 0, PM_REMOVE);

--- a/src/KDFoundation/platform/win32/win32_platform_event_loop.h
+++ b/src/KDFoundation/platform/win32/win32_platform_event_loop.h
@@ -35,8 +35,6 @@ public:
     Win32PlatformEventLoop(Win32PlatformEventLoop &&other) = delete;
     Win32PlatformEventLoop &operator=(Win32PlatformEventLoop &&other) = delete;
 
-    void waitForEvents(int timeout) override;
-
     void wakeUp() override;
 
     bool registerNotifier(FileDescriptorNotifier *notifier) override;
@@ -45,6 +43,7 @@ public:
     std::unordered_map<uintptr_t, Win32PlatformTimer *> timers;
 
 private:
+    void waitForEventsImpl(int timeout) override;
     std::unique_ptr<AbstractPlatformTimer> createPlatformTimerImpl(Timer *timer) override;
 
     struct NotifierSet {

--- a/src/KDGui/platform/android/android_platform_event_loop.cpp
+++ b/src/KDGui/platform/android/android_platform_event_loop.cpp
@@ -84,7 +84,7 @@ AndroidPlatformEventLoop::AndroidPlatformEventLoop(AndroidPlatformIntegration *a
     m_androidPlatformInitegration = androidPlatformInitegration;
 }
 
-void AndroidPlatformEventLoop::waitForEvents(int timeout)
+void AndroidPlatformEventLoop::waitForEventsImpl(int timeout)
 {
     android_poll_source *source;
     if (ALooper_pollAll(timeout, nullptr, nullptr, (void **)&source) >= 0) {

--- a/src/KDGui/platform/android/android_platform_event_loop.h
+++ b/src/KDGui/platform/android/android_platform_event_loop.h
@@ -36,12 +36,6 @@ class KDGUI_API AndroidPlatformEventLoop : public KDFoundation::AbstractPlatform
 public:
     AndroidPlatformEventLoop(AndroidPlatformIntegration *androidPlatformInitegration);
 
-    // timeout in msecs
-    // -1 means wait forever
-    // 0 means do not wait (i.e. poll)
-    // +ve number, wait for up to timeout msecs
-    void waitForEvents(int timeout) override;
-
     // Kick the event loop out of waiting
     void wakeUp() override;
 
@@ -52,6 +46,7 @@ public:
     AndroidPlatformIntegration *androidPlatformIntegration();
 
 protected:
+    void waitForEventsImpl(int timeout) override;
     std::unique_ptr<KDFoundation::AbstractPlatformTimer> createPlatformTimerImpl(KDFoundation::Timer *timer) final;
 
 private:

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
@@ -35,7 +35,7 @@ LinuxWaylandPlatformEventLoop::~LinuxWaylandPlatformEventLoop()
 {
 }
 
-void LinuxWaylandPlatformEventLoop::waitForEvents(int timeout)
+void LinuxWaylandPlatformEventLoop::waitForEventsImpl(int timeout)
 {
     auto dpy = m_platformIntegration->display();
     auto queue = m_platformIntegration->queue();
@@ -46,7 +46,7 @@ void LinuxWaylandPlatformEventLoop::waitForEvents(int timeout)
     }
 
     // Call the base class to do the actual multiplexing
-    LinuxPlatformEventLoop::waitForEvents(timeout);
+    LinuxPlatformEventLoop::waitForEventsImpl(timeout);
 
     int fd = wl_display_get_fd(dpy);
     if (epollEventFromFdPlusType(fd, FileDescriptorNotifier::NotificationType::Read)) {

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.h
@@ -28,7 +28,7 @@ public:
     ~LinuxWaylandPlatformEventLoop();
 
     void init();
-    void waitForEvents(int timeout) override;
+    void waitForEventsImpl(int timeout) override;
 
 private:
     std::shared_ptr<spdlog::logger> m_logger;

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
@@ -51,13 +51,13 @@ LinuxXcbPlatformEventLoop::~LinuxXcbPlatformEventLoop()
 {
 }
 
-void LinuxXcbPlatformEventLoop::waitForEvents(int timeout)
+void LinuxXcbPlatformEventLoop::waitForEventsImpl(int timeout)
 {
     // Process any xcb events already waiting for us
     processXcbEvents();
 
     // Call the base class to do the actual multiplexing
-    LinuxPlatformEventLoop::waitForEvents(timeout);
+    LinuxPlatformEventLoop::waitForEventsImpl(timeout);
 
     // Now we are awake again, check to see if we have any xcb events to process
     if (!m_xcbEventsPending)

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.h
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.h
@@ -32,7 +32,7 @@ public:
     explicit LinuxXcbPlatformEventLoop(LinuxXcbPlatformIntegration *platformIntegration);
     ~LinuxXcbPlatformEventLoop();
 
-    void waitForEvents(int timeout) override;
+    void waitForEventsImpl(int timeout) override;
 
 private:
     void processXcbEvents();


### PR DESCRIPTION
Connection invocations are now evaluated automatically in the event loop. Any time an invocation is enqueued using the event loop's connection evaluator, the event loop is woken up.

This required a KDUtils-specific ConnectionEvaluator.

When given event loop is destroyed, it sets a reference in the evaluator to null. It's a defensive measure for the future to prevent misuse of lingering evaluators in case the user deletes the event loop first.

AbstractEventLoop::waitForEvents is not pure abstract anymore as it ensures evaluation of slot invocations.

Removed one copypasted comment in android event loop impl.