### PR TITLE
Fix clang tidy warnings

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,6 +76,17 @@
             }
         },
         {
+            "name": "release-clangtidy",
+            "displayName": "Release with clang-tidy",
+            "inherits": [
+                "release"
+            ],
+            "binaryDir": "${sourceDir}/build/Release-clangtidy",
+            "cacheVariables": {
+                "CMAKE_CXX_CLANG_TIDY": "clang-tidy"
+            }
+        },
+        {
             "name": "profile",
             "displayName": "Profile",
             "inherits": [

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -74,7 +74,8 @@ if(NOT TARGET KDAB::KDBindings)
     fetchcontent_declare(
         KDBindings
         GIT_REPOSITORY https://github.com/KDAB/KDBindings.git
-        GIT_TAG 4c4d36489b60a3ae5ce17a3dc0b6b7cbf43a9afa # v1.1.0-beta.2
+        GIT_TAG aab1cfd289296972ef32124f749e3b565b634535 # main as of 2024-07-17, needed for noexcept
+                                                         # in destructors
         USES_TERMINAL_DOWNLOAD YES USES_TERMINAL_UPDATE YES
     )
     fetchcontent_makeavailable(KDBindings)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -32,6 +32,7 @@ if(NOT TARGET spdlog::spdlog)
             GIT_TAG e69e5f977d458f2650bb346dadf2ad30c5320281 # 10.2.1
         )
         FetchContent_MakeAvailable(fmt)
+        set_target_properties(fmt PROPERTIES CXX_CLANG_TIDY "")
     endif()
     set(SPDLOG_FMT_EXTERNAL_HO ON)
     # with this spdlog is included as a system library and won't e.g. trigger

--- a/examples/gui_window/gui_window.cpp
+++ b/examples/gui_window/gui_window.cpp
@@ -12,6 +12,8 @@
 #include <KDGui/window.h>
 #include <KDGui/gui_events.h>
 
+#include <tuple>
+
 class ExampleWindow : public KDGui::Window
 {
     void mouseMoveEvent(KDGui::MouseMoveEvent *ev) override
@@ -68,7 +70,7 @@ int main()
     w.title = "KDGui window example";
     w.visible = true;
 
-    w.visible.valueChanged().connect([&app](bool visible) {
+    std::ignore = w.visible.valueChanged().connect([&app](bool visible) {
         if (!visible) {
             app.quit();
         }

--- a/src/KDFoundation/core_application.cpp
+++ b/src/KDFoundation/core_application.cpp
@@ -28,8 +28,7 @@ using namespace KDFoundation;
 CoreApplication *CoreApplication::ms_application = nullptr;
 
 CoreApplication::CoreApplication(std::unique_ptr<AbstractPlatformIntegration> &&platformIntegration)
-    : Object()
-    , m_defaultLogger{ KDUtils::Logger::logger("default_log", spdlog::level::info) }
+    : m_defaultLogger{ KDUtils::Logger::logger("default_log", spdlog::level::info) }
     , m_platformIntegration{ std::move(platformIntegration) }
     , m_logger{ KDUtils::Logger::logger("core_application") }
 {

--- a/src/KDFoundation/core_application.cpp
+++ b/src/KDFoundation/core_application.cpp
@@ -38,7 +38,7 @@ CoreApplication::CoreApplication(std::unique_ptr<AbstractPlatformIntegration> &&
     spdlog::set_default_logger(m_defaultLogger);
 
     // Helps with debugging setup on remote hosts
-    if (const char *display = std::getenv("DISPLAY"))
+    if (const char *display = std::getenv("DISPLAY")) // NOLINT(concurrency-mt-unsafe)
         SPDLOG_LOGGER_INFO(m_logger, "DISPLAY={}", display);
 
     // Create a default postman object

--- a/src/KDFoundation/file_descriptor_notifier.cpp
+++ b/src/KDFoundation/file_descriptor_notifier.cpp
@@ -20,8 +20,7 @@
 using namespace KDFoundation;
 
 FileDescriptorNotifier::FileDescriptorNotifier(int fd, NotificationType type)
-    : Object()
-    , m_fd{ fd }
+    : m_fd{ fd }
     , m_type{ type }
 {
     assert(m_fd >= 0);

--- a/src/KDFoundation/object.h
+++ b/src/KDFoundation/object.h
@@ -29,6 +29,9 @@ class KDFOUNDATION_API Object : public EventReceiver
 {
 public:
     Object();
+    /// @warning This destructor emits #destroyed signal and #childRemoved for each child. If any of
+    /// the slots connected to these signals throws (which is UB in KDBindings anyway) the exception
+    /// will be eaten and error will be logged.
     virtual ~Object();
 
     // Not copyable

--- a/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
@@ -65,7 +65,7 @@ void LinuxPlatformEventLoop::waitForEventsImpl(int timeout)
     const int maxEventCount = 16;
     epoll_event events[maxEventCount];
 
-    int eventCount = epoll_wait(m_epollHandle, events, maxEventCount, timeout);
+    const int eventCount = epoll_wait(m_epollHandle, events, maxEventCount, timeout);
     SPDLOG_DEBUG("epoll_wait() returned {} events within {} msecs", eventCount, timeout);
 
     // Let interested parties know if something happened.
@@ -106,7 +106,7 @@ void LinuxPlatformEventLoop::waitForEventsImpl(int timeout)
 
 void LinuxPlatformEventLoop::wakeUp()
 {
-    eventfd_t value{ 1 };
+    const eventfd_t value{ 1 };
     eventfd_write(m_eventfd, value);
 }
 

--- a/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
@@ -9,6 +9,10 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#if !defined(_GNU_SOURCE)
+#error "Project must be compiled with _GNU_SOURCE define for GNU variant of strerror_r"
+#endif
+
 #include <KDFoundation/platform/linux/linux_platform_event_loop.h>
 #include <KDFoundation/platform/linux/linux_platform_timer.h>
 #include <KDFoundation/event.h>
@@ -16,6 +20,9 @@
 
 #include <unistd.h>
 #include <sys/eventfd.h>
+
+#include <array>
+#include <cstring>
 
 using namespace KDFoundation;
 
@@ -174,7 +181,8 @@ bool LinuxPlatformEventLoop::unregisterFileDescriptor(int fd, FileDescriptorNoti
     // proceed as if unregistering the file descriptor was successful.
     // This way we ensure notifiers are reset / deleted properly.
     if (rv && (errno != EBADF)) {
-        SPDLOG_ERROR("Failed to unregister file descriptor {}. Error {}: {}.", fd, errno, strerror(errno));
+        std::array<char, 64> buf;
+        SPDLOG_ERROR("Failed to unregister file descriptor {}. Error {}: {}.", fd, errno, strerror_r(errno, buf.data(), buf.size()));
         return false;
     }
 

--- a/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
@@ -70,9 +70,9 @@ LinuxPlatformEventLoop::~LinuxPlatformEventLoop()
 void LinuxPlatformEventLoop::waitForEventsImpl(int timeout)
 {
     const int maxEventCount = 16;
-    epoll_event events[maxEventCount];
+    std::array<epoll_event, maxEventCount> events;
 
-    const int eventCount = epoll_wait(m_epollHandle, events, maxEventCount, timeout);
+    const int eventCount = epoll_wait(m_epollHandle, events.data(), events.size(), timeout);
     SPDLOG_DEBUG("epoll_wait() returned {} events within {} msecs", eventCount, timeout);
 
     // Let interested parties know if something happened.

--- a/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
+++ b/src/KDFoundation/platform/linux/linux_platform_event_loop.cpp
@@ -20,7 +20,6 @@
 using namespace KDFoundation;
 
 LinuxPlatformEventLoop::LinuxPlatformEventLoop()
-    : AbstractPlatformEventLoop()
 {
     // We use epoll to multiplex as it has much better performance than
     // select or poll.

--- a/src/KDFoundation/platform/linux/linux_platform_event_loop.h
+++ b/src/KDFoundation/platform/linux/linux_platform_event_loop.h
@@ -49,7 +49,7 @@ public:
 
     int epollEventFromFdPlusType(int fd, FileDescriptorNotifier::NotificationType type);
     int epollEventFromFdMinusType(int fd, FileDescriptorNotifier::NotificationType type);
-    int epollEventFromNotifierTypes(bool read, bool write, bool exception);
+    static int epollEventFromNotifierTypes(bool read, bool write, bool exception);
 
 protected:
     void waitForEventsImpl(int timeout) override;

--- a/src/KDFoundation/platform/linux/linux_platform_timer.cpp
+++ b/src/KDFoundation/platform/linux/linux_platform_timer.cpp
@@ -11,12 +11,15 @@
 
 #include <KDFoundation/platform/linux/linux_platform_timer.h>
 
-#include <unistd.h>
-#include <sys/timerfd.h>
-
 #include "KDFoundation/core_application.h"
 #include "KDFoundation/timer.h"
 #include "KDFoundation/platform/linux/linux_platform_event_loop.h"
+
+#include <unistd.h>
+#include <sys/timerfd.h>
+
+#include <array>
+#include <tuple>
 
 using namespace KDFoundation;
 
@@ -24,9 +27,8 @@ LinuxPlatformTimer::LinuxPlatformTimer(Timer *timer)
     : m_notifier(timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC), FileDescriptorNotifier::NotificationType::Read)
 {
     m_notifierConnection = m_notifier.triggered.connect([this, timer]() {
-        char buf[8];
-        const auto bytes = read(m_notifier.fileDescriptor(), buf, 8);
-        KD_UNUSED(bytes);
+        std::array<char, 8> buf;
+        std::ignore = read(m_notifier.fileDescriptor(), buf.data(), buf.size());
         timer->timeout.emit();
     });
 

--- a/src/KDFoundation/platform/linux/linux_platform_timer.cpp
+++ b/src/KDFoundation/platform/linux/linux_platform_timer.cpp
@@ -61,7 +61,7 @@ void LinuxPlatformTimer::arm(std::chrono::microseconds us)
     timespec time;
     time.tv_sec = us.count() / 1'000'000;
     time.tv_nsec = (us.count() - time.tv_sec * 1'000'000) * 1000;
-    itimerspec spec = {
+    const itimerspec spec = {
         .it_interval = time,
         .it_value = time
     };
@@ -70,8 +70,8 @@ void LinuxPlatformTimer::arm(std::chrono::microseconds us)
 
 void LinuxPlatformTimer::disarm()
 {
-    timespec time = { 0, 0 };
-    itimerspec spec = {
+    const timespec time = { 0, 0 };
+    const itimerspec spec = {
         .it_interval = time,
         .it_value = time
     };

--- a/src/KDFoundation/platform/linux/linux_platform_timer.h
+++ b/src/KDFoundation/platform/linux/linux_platform_timer.h
@@ -13,6 +13,8 @@
 
 #include <chrono>
 
+#include <kdbindings/signal.h>
+
 #include <KDFoundation/platform/abstract_platform_timer.h>
 #include <KDFoundation/file_descriptor_notifier.h>
 
@@ -35,6 +37,9 @@ private:
         int fd;
     } m_fdCloser;
     FileDescriptorNotifier m_notifier;
+    KDBindings::ScopedConnection m_notifierConnection;
+    KDBindings::ScopedConnection m_timerRunningConnection;
+    KDBindings::ScopedConnection m_timerIntervalConnection;
 };
 
 } // namespace KDFoundation

--- a/src/KDFoundation/platform/win32/win32_platform_timer.cpp
+++ b/src/KDFoundation/platform/win32/win32_platform_timer.cpp
@@ -27,14 +27,14 @@ inline Win32PlatformEventLoop *eventLoop()
 Win32PlatformTimer::Win32PlatformTimer(Timer *timer)
     : m_timer(timer)
 {
-    timer->running.valueChanged().connect([this, timer](bool running) {
+    m_timerRunningConnection = timer->running.valueChanged().connect([this, timer](bool running) {
         if (running) {
             arm(timer->interval.get());
         } else {
             disarm();
         }
     });
-    timer->interval.valueChanged().connect([this, timer]() {
+    m_timerIntervalConnection = timer->interval.valueChanged().connect([this, timer]() {
         if (timer->running.get()) {
             arm(timer->interval.get());
         }

--- a/src/KDFoundation/platform/win32/win32_platform_timer.h
+++ b/src/KDFoundation/platform/win32/win32_platform_timer.h
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <windows.h>
+#include <kdbindings/signal.h>
 #undef max
 
 #include <KDFoundation/platform/abstract_platform_timer.h>
@@ -33,6 +34,8 @@ private:
     static void callback(HWND hwnd, UINT uMsg, UINT_PTR timerId, DWORD dwTime);
 
     Timer *m_timer;
+    KDBindings::ScopedConnection m_timerRunningConnection;
+    KDBindings::ScopedConnection m_timerIntervalConnection;
     uintptr_t m_id{ 0 };
 };
 

--- a/src/KDGui/abstract_platform_window.cpp
+++ b/src/KDGui/abstract_platform_window.cpp
@@ -21,7 +21,7 @@ AbstractPlatformWindow::AbstractPlatformWindow(Window *window, AbstractPlatformW
     , m_type(type)
 {
     assert(window);
-    window->title.valueChanged().connect(&AbstractPlatformWindow::setTitle, this);
+    m_titleChangedConnection = window->title.valueChanged().connect(&AbstractPlatformWindow::setTitle, this);
 }
 
 AbstractPlatformWindow::Type AbstractPlatformWindow::type() const

--- a/src/KDGui/abstract_platform_window.h
+++ b/src/KDGui/abstract_platform_window.h
@@ -15,6 +15,8 @@
 #include <KDGui/kdgui_keys.h>
 #include <KDGui/gui_events.h>
 
+#include <kdbindings/signal.h>
+
 #include <string>
 
 namespace KDGui {
@@ -86,6 +88,7 @@ public:
 
 protected:
     Window *m_window;
+    KDBindings::ScopedConnection m_titleChangedConnection;
     AbstractPlatformWindow::Type m_type;
 };
 

--- a/src/KDGui/gui_application.cpp
+++ b/src/KDGui/gui_application.cpp
@@ -33,7 +33,7 @@ static std::unique_ptr<KDGui::AbstractGuiPlatformIntegration> createLinuxIntegra
     bool prefersXcb = false;
 
     // TODO(doc): document this behavior
-    if (const char *preferredPlatform = std::getenv("KDGUI_PLATFORM")) {
+    if (const char *preferredPlatform = std::getenv("KDGUI_PLATFORM")) { //NOLINT(concurrency-mt-unsafe)
         prefersXcb = std::string_view{ preferredPlatform } == "xcb";
     }
 

--- a/src/KDGui/gui_application.cpp
+++ b/src/KDGui/gui_application.cpp
@@ -27,13 +27,14 @@
 
 using namespace KDGui;
 
+namespace {
 #if defined(PLATFORM_LINUX)
-static std::unique_ptr<KDGui::AbstractGuiPlatformIntegration> createLinuxIntegration()
+std::unique_ptr<KDGui::AbstractGuiPlatformIntegration> createLinuxIntegration()
 {
     bool prefersXcb = false;
 
     // TODO(doc): document this behavior
-    if (const char *preferredPlatform = std::getenv("KDGUI_PLATFORM")) { //NOLINT(concurrency-mt-unsafe)
+    if (const char *preferredPlatform = std::getenv("KDGUI_PLATFORM")) { // NOLINT(concurrency-mt-unsafe)
         prefersXcb = std::string_view{ preferredPlatform } == "xcb";
     }
 
@@ -46,7 +47,7 @@ static std::unique_ptr<KDGui::AbstractGuiPlatformIntegration> createLinuxIntegra
 }
 #endif
 
-static std::unique_ptr<AbstractGuiPlatformIntegration> createPlatformIntegration()
+std::unique_ptr<AbstractGuiPlatformIntegration> createPlatformIntegration()
 {
 #if defined(ANDROID)
     return std::make_unique<AndroidPlatformIntegration>();
@@ -59,6 +60,7 @@ static std::unique_ptr<AbstractGuiPlatformIntegration> createPlatformIntegration
 #endif
     return {};
 }
+} // namespace
 
 GuiApplication::GuiApplication(std::unique_ptr<AbstractGuiPlatformIntegration> &&platformIntegration)
     : CoreApplication(platformIntegration ? std::move(platformIntegration) : createPlatformIntegration())

--- a/src/KDGui/platform/linux/wayland/linux_wayland_clipboard.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_clipboard.cpp
@@ -80,19 +80,23 @@ LinuxWaylandClipboard::LinuxWaylandClipboard(KDGui::LinuxWaylandPlatformIntegrat
 {
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandClipboard::dataOffer(wl_data_device *data_device, wl_data_offer *offer)
 {
     m_dataOffer = offer;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandClipboard::dragEnter(wl_data_device *wl_data_device, uint32_t serial, wl_surface *surface, wl_fixed_t x, wl_fixed_t y, wl_data_offer *id)
 {
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandClipboard::dragLeave(wl_data_device *wl_data_device)
 {
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandClipboard::dragMotion(wl_data_device *wl_data_device, uint32_t time, wl_fixed_t x, wl_fixed_t y)
 {
 }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_clipboard.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_clipboard.cpp
@@ -81,7 +81,7 @@ LinuxWaylandClipboard::LinuxWaylandClipboard(KDGui::LinuxWaylandPlatformIntegrat
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void LinuxWaylandClipboard::dataOffer(wl_data_device *data_device, wl_data_offer *offer)
+void LinuxWaylandClipboard::dataOffer(wl_data_device * /*data_device*/, wl_data_offer *offer)
 {
     m_dataOffer = offer;
 }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
@@ -26,7 +26,7 @@ void LinuxWaylandPlatformEventLoop::init()
 {
     m_logger = m_platformIntegration->logger();
 
-    int fd = wl_display_get_fd(m_platformIntegration->display());
+    const int fd = wl_display_get_fd(m_platformIntegration->display());
     registerFileDescriptor(fd, FileDescriptorNotifier::NotificationType::Read);
 }
 
@@ -47,7 +47,7 @@ void LinuxWaylandPlatformEventLoop::waitForEventsImpl(int timeout)
     // Call the base class to do the actual multiplexing
     LinuxPlatformEventLoop::waitForEventsImpl(timeout);
 
-    int fd = wl_display_get_fd(dpy);
+    const int fd = wl_display_get_fd(dpy);
     if (epollEventFromFdPlusType(fd, FileDescriptorNotifier::NotificationType::Read)) {
         wl_display_read_events(dpy);
         wl_display_dispatch_queue_pending(dpy, queue);

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
@@ -18,8 +18,7 @@ using namespace KDGui;
 using namespace KDFoundation;
 
 LinuxWaylandPlatformEventLoop::LinuxWaylandPlatformEventLoop(LinuxWaylandPlatformIntegration *platformIntegration)
-    : LinuxPlatformEventLoop()
-    , m_platformIntegration{ platformIntegration }
+    : m_platformIntegration{ platformIntegration }
 {
 }
 

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
@@ -26,6 +26,8 @@
 #include <wayland-zwp-relative-pointer-unstable-v1-client-protocol.h>
 #include <wayland-zwp-pointer-constraints-v1-client-protocol.h>
 
+#include <tuple>
+
 using namespace KDGui;
 
 LinuxWaylandPlatformInput::LinuxWaylandPlatformInput(LinuxWaylandPlatformIntegration *integration,
@@ -41,7 +43,7 @@ LinuxWaylandPlatformInput::LinuxWaylandPlatformInput(LinuxWaylandPlatformIntegra
     };
     wl_seat_add_listener(seat, &listener, this);
 
-    m_keyboard.repeat.timer.timeout.connect(&LinuxWaylandPlatformInput::keyboardRepeatKey, this);
+    std::ignore = m_keyboard.repeat.timer.timeout.connect(&LinuxWaylandPlatformInput::keyboardRepeatKey, this);
 }
 
 LinuxWaylandPlatformInput::~LinuxWaylandPlatformInput()
@@ -223,7 +225,7 @@ void LinuxWaylandPlatformInput::pointerEnter(wl_pointer *pointer, uint32_t seria
         m_pointer.accumulatedEvent.focusChange = true;
     } else {
         m_pointer.focus = LinuxWaylandPlatformWindow::fromSurface(surface);
-        m_pointer.focus->cursorChanged.connect(&LinuxWaylandPlatformInput::setCursor, this);
+        std::ignore = m_pointer.focus->cursorChanged.connect(&LinuxWaylandPlatformInput::setCursor, this);
         setCursor();
     }
 }
@@ -333,7 +335,7 @@ void LinuxWaylandPlatformInput::pointerFrame(wl_pointer *pointer)
     auto &ev = m_pointer.accumulatedEvent;
     if (ev.focusChange && ev.focus) {
         m_pointer.focus = ev.focus;
-        m_pointer.focus->cursorChanged.connect(&LinuxWaylandPlatformInput::setCursor, this);
+        std::ignore = m_pointer.focus->cursorChanged.connect(&LinuxWaylandPlatformInput::setCursor, this);
         setCursor();
     }
 

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
@@ -374,9 +374,9 @@ void LinuxWaylandPlatformInput::pointerAxisDiscrete(wl_pointer *pointer, uint32_
 void LinuxWaylandPlatformInput::pointerRelativeMotionV1(zwp_relative_pointer_v1 *pointer, uint32_t utimeHi, uint32_t utimeLow,
                                                         wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t dxUnaccel, wl_fixed_t dyUnaccel)
 {
-    Position pos{ wl_fixed_to_int(dx), wl_fixed_to_int(dy) };
-    uint64_t utime = uint64_t(utimeHi) << 32 | utimeLow;
-    uint32_t time = utime / 1000;
+    const Position pos{ wl_fixed_to_int(dx), wl_fixed_to_int(dy) };
+    const uint64_t utime = uint64_t(utimeHi) << 32 | utimeLow;
+    const uint32_t time = utime / 1000;
 
     if (m_version >= WL_POINTER_FRAME_SINCE_VERSION) {
         m_pointer.accumulatedEvent.delta = pos;

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
@@ -505,7 +505,7 @@ void LinuxWaylandPlatformInput::touchDown(wl_touch *touch, uint32_t serial, uint
                                           wl_surface *surface, int32_t id, wl_fixed_t x, wl_fixed_t y)
 {
     // We don't support touch yet, so just use the first touch point as mouse input
-    if (m_touch.points.size() > 0) {
+    if (!m_touch.points.empty()) {
         return;
     }
 
@@ -543,7 +543,7 @@ void LinuxWaylandPlatformInput::touchFrame(wl_touch *touch)
 
 void LinuxWaylandPlatformInput::touchCancel(wl_touch *touch)
 {
-    if (m_touch.points.size() > 0) {
+    if (!m_touch.points.empty()) {
         m_touch.focus->handleMouseRelease(m_touch.time, MouseButton::LeftButton, int16_t(m_touch.points[0].pos.x), int16_t(m_touch.points[0].pos.y));
         m_touch.points.clear();
     }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
@@ -30,6 +30,9 @@
 
 using namespace KDGui;
 
+// Wayland requires lots of callbacks that trip this check so turn it off for the entire file
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+
 LinuxWaylandPlatformInput::LinuxWaylandPlatformInput(LinuxWaylandPlatformIntegration *integration,
                                                      wl_seat *seat, uint32_t version, uint32_t id)
     : m_integration(integration)
@@ -457,6 +460,7 @@ void LinuxWaylandPlatformInput::keybordKey(wl_keyboard *keyboard, uint32_t seria
         // Get the modifier state
         const auto modifiers = xkb::modifierState(m_keyboard.state);
 
+        // NOLINTNEXTLINE(readability-suspicious-call-argument)
         m_keyboard.focus->handleKeyRelease(time, keycode, skey, modifiers);
         m_keyboard.repeat.timer.running = false;
     }
@@ -558,3 +562,4 @@ void LinuxWaylandPlatformInput::touchShape(wl_touch *touch, int32_t id, wl_fixed
 void LinuxWaylandPlatformInput::touchOrientation(wl_touch *touch, int32_t id, wl_fixed_t orientation)
 {
 }
+// NOLINTEND(bugprone-easily-swappable-parameters)

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
@@ -403,7 +403,7 @@ void LinuxWaylandPlatformInput::keyboardKeymap(wl_keyboard * /*keyboard*/, uint3
         return;
     }
 
-    char *map = static_cast<char *>(mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0));
+    char *map = static_cast<char *>(mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0));
     if (!map) {
         SPDLOG_LOGGER_ERROR(m_integration->logger(), "mmapping the keymap fd failed!");
         close(fd);

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
@@ -466,6 +466,7 @@ void LinuxWaylandPlatformInput::keybordKey(wl_keyboard * /*keyboard*/, uint32_t 
     }
 }
 
+// NOLINTNEXTLINE(readability-make-member-function-const)
 void LinuxWaylandPlatformInput::keyboardModifiers(wl_keyboard * /*keyboard*/, uint32_t /*serial*/, uint32_t depressed,
                                                   uint32_t latched, uint32_t locked, uint32_t group)
 {

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.cpp
@@ -84,7 +84,7 @@ void LinuxWaylandPlatformInput::destroyPointerConstraintsV1()
     }
 }
 
-void LinuxWaylandPlatformInput::capabilities(wl_seat *seat, uint32_t caps)
+void LinuxWaylandPlatformInput::capabilities(wl_seat * /*seat*/, uint32_t caps)
 {
     const bool hasPointer = caps & WL_SEAT_CAPABILITY_POINTER;
     if (hasPointer && !m_pointer.pointer) {
@@ -108,7 +108,7 @@ void LinuxWaylandPlatformInput::capabilities(wl_seat *seat, uint32_t caps)
     }
 }
 
-void LinuxWaylandPlatformInput::name(wl_seat *seat, const char *name)
+void LinuxWaylandPlatformInput::name(wl_seat * /*seat*/, const char *name)
 {
     m_name = name;
 }
@@ -218,7 +218,7 @@ void LinuxWaylandPlatformInput::destroyTouch()
     m_touch.touch = nullptr;
 }
 
-void LinuxWaylandPlatformInput::pointerEnter(wl_pointer *pointer, uint32_t serial, wl_surface *surface, wl_fixed_t x, wl_fixed_t y)
+void LinuxWaylandPlatformInput::pointerEnter(wl_pointer * /*pointer*/, uint32_t serial, wl_surface *surface, wl_fixed_t x, wl_fixed_t y)
 {
     m_pointer.pos = { wl_fixed_to_int(x), wl_fixed_to_int(y) };
     m_pointer.lastSerial = serial;
@@ -272,7 +272,7 @@ void LinuxWaylandPlatformInput::pointerLock()
     }
 }
 
-void LinuxWaylandPlatformInput::pointerLeave(wl_pointer *pointer, uint32_t serial, wl_surface *surface)
+void LinuxWaylandPlatformInput::pointerLeave(wl_pointer * /*pointer*/, uint32_t serial, wl_surface * /*surface*/)
 {
     if (m_version >= WL_POINTER_FRAME_SINCE_VERSION) {
         m_pointer.accumulatedEvent.focus = nullptr;
@@ -284,7 +284,7 @@ void LinuxWaylandPlatformInput::pointerLeave(wl_pointer *pointer, uint32_t seria
     m_pointer.lastSerial = serial;
 }
 
-void LinuxWaylandPlatformInput::pointerMotion(wl_pointer *pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y)
+void LinuxWaylandPlatformInput::pointerMotion(wl_pointer * /*pointer*/, uint32_t time, wl_fixed_t x, wl_fixed_t y)
 {
     m_pointer.pos = { wl_fixed_to_int(x), wl_fixed_to_int(y) };
     if (m_version >= WL_POINTER_FRAME_SINCE_VERSION) {
@@ -295,7 +295,7 @@ void LinuxWaylandPlatformInput::pointerMotion(wl_pointer *pointer, uint32_t time
     }
 }
 
-void LinuxWaylandPlatformInput::pointerButton(wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
+void LinuxWaylandPlatformInput::pointerButton(wl_pointer * /*pointer*/, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
 {
     const MouseButton btn = [=]() {
         switch (button) {
@@ -319,7 +319,7 @@ void LinuxWaylandPlatformInput::pointerButton(wl_pointer *pointer, uint32_t seri
     m_pointer.lastSerial = serial;
 }
 
-void LinuxWaylandPlatformInput::pointerAxis(wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value)
+void LinuxWaylandPlatformInput::pointerAxis(wl_pointer * /*pointer*/, uint32_t time, uint32_t axis, wl_fixed_t value)
 {
     const double delta = -wl_fixed_to_double(value);
     const int32_t xDelta = axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL ? int32_t(delta) : 0;
@@ -333,7 +333,7 @@ void LinuxWaylandPlatformInput::pointerAxis(wl_pointer *pointer, uint32_t time, 
     }
 }
 
-void LinuxWaylandPlatformInput::pointerFrame(wl_pointer *pointer)
+void LinuxWaylandPlatformInput::pointerFrame(wl_pointer * /*pointer*/)
 {
     auto &ev = m_pointer.accumulatedEvent;
     if (ev.focusChange && ev.focus) {
@@ -374,8 +374,8 @@ void LinuxWaylandPlatformInput::pointerAxisDiscrete(wl_pointer *pointer, uint32_
 {
 }
 
-void LinuxWaylandPlatformInput::pointerRelativeMotionV1(zwp_relative_pointer_v1 *pointer, uint32_t utimeHi, uint32_t utimeLow,
-                                                        wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t dxUnaccel, wl_fixed_t dyUnaccel)
+void LinuxWaylandPlatformInput::pointerRelativeMotionV1(zwp_relative_pointer_v1 * /*pointer*/, uint32_t utimeHi, uint32_t utimeLow,
+                                                        wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t /*dxUnaccel*/, wl_fixed_t /*dyUnaccel*/)
 {
     const Position pos{ wl_fixed_to_int(dx), wl_fixed_to_int(dy) };
     const uint64_t utime = uint64_t(utimeHi) << 32 | utimeLow;
@@ -389,7 +389,7 @@ void LinuxWaylandPlatformInput::pointerRelativeMotionV1(zwp_relative_pointer_v1 
     }
 }
 
-void LinuxWaylandPlatformInput::keyboardKeymap(wl_keyboard *keyboard, uint32_t format, int fd, uint32_t size)
+void LinuxWaylandPlatformInput::keyboardKeymap(wl_keyboard * /*keyboard*/, uint32_t format, int fd, uint32_t size)
 {
     if (m_keyboard.keymap) {
         xkb_state_unref(m_keyboard.state);
@@ -417,20 +417,20 @@ void LinuxWaylandPlatformInput::keyboardKeymap(wl_keyboard *keyboard, uint32_t f
     m_keyboard.state = xkb_state_new(m_keyboard.keymap);
 }
 
-void LinuxWaylandPlatformInput::keyboardEnter(wl_keyboard *keyboard, uint32_t serial, wl_surface *surface, wl_array *keys)
+void LinuxWaylandPlatformInput::keyboardEnter(wl_keyboard * /*keyboard*/, uint32_t serial, wl_surface *surface, wl_array * /*keys*/)
 {
     m_keyboard.focus = LinuxWaylandPlatformWindow::fromSurface(surface);
     m_keyboard.serial = serial;
 }
 
-void LinuxWaylandPlatformInput::keyboardLeave(wl_keyboard *keyboard, uint32_t serial, wl_surface *surface)
+void LinuxWaylandPlatformInput::keyboardLeave(wl_keyboard * /*keyboard*/, uint32_t /*serial*/, wl_surface * /*surface*/)
 {
     m_keyboard.focus = nullptr;
     m_keyboard.repeat.timer.running = false;
     m_keyboard.serial = 0;
 }
 
-void LinuxWaylandPlatformInput::keybordKey(wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+void LinuxWaylandPlatformInput::keybordKey(wl_keyboard * /*keyboard*/, uint32_t /*serial*/, uint32_t time, uint32_t key, uint32_t state)
 {
     if (!m_keyboard.state) {
         return;
@@ -466,7 +466,7 @@ void LinuxWaylandPlatformInput::keybordKey(wl_keyboard *keyboard, uint32_t seria
     }
 }
 
-void LinuxWaylandPlatformInput::keyboardModifiers(wl_keyboard *keyboard, uint32_t serial, uint32_t depressed,
+void LinuxWaylandPlatformInput::keyboardModifiers(wl_keyboard * /*keyboard*/, uint32_t /*serial*/, uint32_t depressed,
                                                   uint32_t latched, uint32_t locked, uint32_t group)
 {
     if (m_keyboard.state) {
@@ -474,7 +474,7 @@ void LinuxWaylandPlatformInput::keyboardModifiers(wl_keyboard *keyboard, uint32_
     }
 }
 
-void LinuxWaylandPlatformInput::keyboardRepeatInfo(wl_keyboard *keyboard, int32_t rate, int32_t delay)
+void LinuxWaylandPlatformInput::keyboardRepeatInfo(wl_keyboard * /*keyboard*/, int32_t rate, int32_t delay)
 {
     m_keyboard.repeat.delay = delay;
     m_keyboard.repeat.rate = 1000 / rate;
@@ -507,7 +507,7 @@ void LinuxWaylandPlatformInput::keyboardSendKeyPress(uint32_t time, bool isRepea
     }
 }
 
-void LinuxWaylandPlatformInput::touchDown(wl_touch *touch, uint32_t serial, uint32_t time,
+void LinuxWaylandPlatformInput::touchDown(wl_touch * /*touch*/, uint32_t /*serial*/, uint32_t time,
                                           wl_surface *surface, int32_t id, wl_fixed_t x, wl_fixed_t y)
 {
     // We don't support touch yet, so just use the first touch point as mouse input
@@ -523,7 +523,7 @@ void LinuxWaylandPlatformInput::touchDown(wl_touch *touch, uint32_t serial, uint
     m_touch.focus->handleMousePress(time, MouseButton::LeftButton, int16_t(m_touch.points[0].pos.x), int16_t(m_touch.points[0].pos.y));
 }
 
-void LinuxWaylandPlatformInput::touchUp(wl_touch *touch, uint32_t serial, uint32_t time, int32_t id)
+void LinuxWaylandPlatformInput::touchUp(wl_touch * /*touch*/, uint32_t /*serial*/, uint32_t time, int32_t id)
 {
     if (id != m_touch.points[0].id) {
         return;
@@ -533,7 +533,7 @@ void LinuxWaylandPlatformInput::touchUp(wl_touch *touch, uint32_t serial, uint32
     m_touch.points.clear();
 }
 
-void LinuxWaylandPlatformInput::touchMotion(wl_touch *touch, uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y)
+void LinuxWaylandPlatformInput::touchMotion(wl_touch * /*touch*/, uint32_t time, int32_t id, wl_fixed_t /*x*/, wl_fixed_t /*y*/)
 {
     if (id != m_touch.points[0].id) {
         return;
@@ -547,7 +547,7 @@ void LinuxWaylandPlatformInput::touchFrame(wl_touch *touch)
 {
 }
 
-void LinuxWaylandPlatformInput::touchCancel(wl_touch *touch)
+void LinuxWaylandPlatformInput::touchCancel(wl_touch * /*touch*/)
 {
     if (!m_touch.points.empty()) {
         m_touch.focus->handleMouseRelease(m_touch.time, MouseButton::LeftButton, int16_t(m_touch.points[0].pos.x), int16_t(m_touch.points[0].pos.y));

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.h
@@ -55,7 +55,7 @@ public:
     void destroyPointerConstraintsV1();
 
 private:
-    void capabilities(wl_seat *seaat, uint32_t caps);
+    void capabilities(wl_seat *seat, uint32_t caps);
     void name(wl_seat *seat, const char *name);
 
     void initPointer();

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
@@ -24,6 +24,8 @@
 #include <wayland-zwp-pointer-constraints-v1-client-protocol.h>
 #include <wayland-xdg-decoration-unstable-v1-client-protocol.h>
 
+#include <cstdlib>
+
 using namespace KDGui;
 
 LinuxWaylandPlatformIntegration::LinuxWaylandPlatformIntegration()
@@ -49,7 +51,7 @@ void LinuxWaylandPlatformIntegration::init()
 {
     m_logger = KDUtils::Logger::logger("wayland", spdlog::level::info);
 
-    SPDLOG_LOGGER_INFO(m_logger, "Wayland display is: {}", getenv("WAYLAND_DISPLAY"));
+    SPDLOG_LOGGER_INFO(m_logger, "Wayland display is: {}", std::getenv("WAYLAND_DISPLAY")); // NOLINT(concurrency-mt-unsafe)
 
     m_display = wl_display_connect(nullptr);
     if (!m_display) {

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
@@ -206,6 +206,7 @@ void LinuxWaylandPlatformIntegration::globalRemove(wl_registry *registry, uint32
     }
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void LinuxWaylandPlatformIntegration::ping(xdg_wm_base *xdgShell, uint32_t serial)
 {
     xdg_wm_base_pong(xdgShell, serial);

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
@@ -170,7 +170,7 @@ void LinuxWaylandPlatformIntegration::global(wl_registry *registry, uint32_t id,
     }
 }
 
-void LinuxWaylandPlatformIntegration::globalRemove(wl_registry *registry, uint32_t id)
+void LinuxWaylandPlatformIntegration::globalRemove(wl_registry * /*registry*/, uint32_t id)
 {
     auto findSeat = [this](uint32_t id) {
         return std::find_if(m_inputs.begin(), m_inputs.end(), [id](const auto &input) { return input->seatId() == id; });

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_output.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_output.cpp
@@ -16,6 +16,7 @@
 
 using namespace KDGui;
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 LinuxWaylandPlatformOutput::LinuxWaylandPlatformOutput(wl_output *output, uint32_t version, uint32_t id)
     : m_output(output)
     , m_version(version)
@@ -44,6 +45,7 @@ LinuxWaylandPlatformOutput *LinuxWaylandPlatformOutput::fromOutput(wl_output *ou
     return static_cast<LinuxWaylandPlatformOutput *>(wl_output_get_user_data(output));
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandPlatformOutput::geometry(wl_output *output, int32_t x, int32_t y, int32_t physicalWidth, int32_t physicalHeight,
                                           int32_t subpixel, const char *make, const char *model, int32_t transform)
 {
@@ -51,6 +53,7 @@ void LinuxWaylandPlatformOutput::geometry(wl_output *output, int32_t x, int32_t 
     m_model = model;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandPlatformOutput::mode(wl_output *output, uint32_t flags, int32_t width, int32_t height, int32_t refreshRate)
 {
 }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_output.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_output.cpp
@@ -46,8 +46,8 @@ LinuxWaylandPlatformOutput *LinuxWaylandPlatformOutput::fromOutput(wl_output *ou
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void LinuxWaylandPlatformOutput::geometry(wl_output *output, int32_t x, int32_t y, int32_t physicalWidth, int32_t physicalHeight,
-                                          int32_t subpixel, const char *make, const char *model, int32_t transform)
+void LinuxWaylandPlatformOutput::geometry(wl_output * /*output*/, int32_t /*x*/, int32_t /*y*/, int32_t /*physicalWidth*/, int32_t /*physicalHeight*/,
+                                          int32_t /*subpixel*/, const char *make, const char *model, int32_t /*transform*/)
 {
     m_make = make;
     m_model = model;
@@ -62,7 +62,7 @@ void LinuxWaylandPlatformOutput::done(wl_output *output)
 {
 }
 
-void LinuxWaylandPlatformOutput::scale(wl_output *output, int32_t factor)
+void LinuxWaylandPlatformOutput::scale(wl_output * /*output*/, int32_t factor)
 {
     m_scaleFactor = factor;
 }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -24,6 +24,7 @@
 
 #include <array>
 #include <cassert>
+#include <tuple>
 
 using namespace KDFoundation;
 using namespace KDGui;
@@ -34,12 +35,12 @@ LinuxWaylandPlatformWindow::LinuxWaylandPlatformWindow(
     : AbstractPlatformWindow(window, AbstractPlatformWindow::Type::Wayland)
     , m_platformIntegration{ platformIntegration }
 {
-    CoreApplication::instance()->applicationName.valueChanged().connect([this]() {
+    std::ignore = CoreApplication::instance()->applicationName.valueChanged().connect([this]() {
         if (m_toplevel) {
             setAppId();
         }
     });
-    window->scaleFactor.valueChanged().connect([this](float value) {
+    m_scaleChangedConnection = window->scaleFactor.valueChanged().connect([this](float value) {
         if (m_surface) {
             wl_surface_set_buffer_scale(m_surface, int32_t(value));
         }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -300,7 +300,8 @@ void LinuxWaylandPlatformWindow::updateScaleFactor()
     window()->scaleFactor = factor;
 }
 
-int32_t LinuxWaylandPlatformWindow::scaleByFactor(const int32_t value) const
+template<typename T>
+T LinuxWaylandPlatformWindow::scaleByFactor(T value) const
 {
-    return value * m_window->scaleFactor.get();
+    return value * m_window->scaleFactor.get(); // NOLINT(bugprone-narrowing-conversions)
 }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -230,7 +230,7 @@ void LinuxWaylandPlatformWindow::handleTextInput(const std::string &str)
     CoreApplication::instance()->sendEvent(m_window, &ev);
 }
 
-void LinuxWaylandPlatformWindow::enter(wl_surface *surface, wl_output *output)
+void LinuxWaylandPlatformWindow::enter(wl_surface * /*surface*/, wl_output *output)
 {
     auto o = LinuxWaylandPlatformOutput::fromOutput(output);
     m_enteredOutputs.push_back(o);
@@ -238,7 +238,7 @@ void LinuxWaylandPlatformWindow::enter(wl_surface *surface, wl_output *output)
     updateScaleFactor();
 }
 
-void LinuxWaylandPlatformWindow::leave(wl_surface *surface, wl_output *output)
+void LinuxWaylandPlatformWindow::leave(wl_surface * /*surface*/, wl_output *output)
 {
     auto o = LinuxWaylandPlatformOutput::fromOutput(output);
     auto it = std::find(m_enteredOutputs.begin(), m_enteredOutputs.end(), o);
@@ -255,21 +255,21 @@ void LinuxWaylandPlatformWindow::configure(xdg_surface *xdgSurface, uint32_t ser
     xdg_surface_ack_configure(xdgSurface, serial);
 }
 
-void LinuxWaylandPlatformWindow::configureToplevel(xdg_toplevel *toplevel, int32_t width, int32_t height, wl_array *states)
+void LinuxWaylandPlatformWindow::configureToplevel(xdg_toplevel * /*toplevel*/, int32_t width, int32_t height, wl_array * /*states*/)
 {
     if (width != 0 && height != 0) {
         handleResize(width, height);
     }
 }
 
-void LinuxWaylandPlatformWindow::close(xdg_toplevel *toplevel)
+void LinuxWaylandPlatformWindow::close(xdg_toplevel * /*toplevel*/)
 {
     SPDLOG_LOGGER_DEBUG(m_platformIntegration->logger(), "Window closed by user");
     window()->visible = false;
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void LinuxWaylandPlatformWindow::configureBounds(xdg_toplevel *toplevel, int32_t width, int32_t height)
+void LinuxWaylandPlatformWindow::configureBounds(xdg_toplevel * /*toplevel*/, int32_t width, int32_t height)
 {
     int32_t w = int32_t(window()->width());
     int32_t h = int32_t(window()->height());

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -271,8 +271,8 @@ void LinuxWaylandPlatformWindow::close(xdg_toplevel * /*toplevel*/)
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandPlatformWindow::configureBounds(xdg_toplevel * /*toplevel*/, int32_t width, int32_t height)
 {
-    int32_t w = int32_t(window()->width());
-    int32_t h = int32_t(window()->height());
+    auto w = int32_t(window()->width());
+    auto h = int32_t(window()->height());
     if (width != 0 && width < w) {
         w = width;
     }
@@ -295,7 +295,7 @@ void LinuxWaylandPlatformWindow::updateScaleFactor()
     // use the highest scale factor of all the outputs this window is visible on
     float factor = 1;
     for (auto *output : m_enteredOutputs) {
-        const float outputScaleFactor = float(output->scaleFactor());
+        const auto outputScaleFactor = float(output->scaleFactor());
         if (outputScaleFactor > factor) {
             factor = outputScaleFactor;
         }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -199,7 +199,7 @@ void LinuxWaylandPlatformWindow::handleMouseMove(uint32_t timestamp, MouseButton
 void LinuxWaylandPlatformWindow::handleMouseMoveRelative(uint32_t timestamp, int64_t dx, int64_t dy)
 {
     if (m_cursorMode == CursorMode::Disabled) {
-        Position pos = window()->cursorPosition.get() + Position(dx, dy);
+        const Position pos = window()->cursorPosition.get() + Position(dx, dy);
         MouseMoveEvent ev{ timestamp, MouseButton::NoButton, pos.x, pos.y };
         CoreApplication::instance()->sendEvent(m_window, &ev);
     }

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -248,6 +248,7 @@ void LinuxWaylandPlatformWindow::leave(wl_surface *surface, wl_output *output)
     updateScaleFactor();
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void LinuxWaylandPlatformWindow::configure(xdg_surface *xdgSurface, uint32_t serial)
 {
     xdg_surface_ack_configure(xdgSurface, serial);

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -196,6 +196,7 @@ void LinuxWaylandPlatformWindow::handleMouseMove(uint32_t timestamp, MouseButton
     }
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandPlatformWindow::handleMouseMoveRelative(uint32_t timestamp, int64_t dx, int64_t dy)
 {
     if (m_cursorMode == CursorMode::Disabled) {
@@ -267,6 +268,7 @@ void LinuxWaylandPlatformWindow::close(xdg_toplevel *toplevel)
     window()->visible = false;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void LinuxWaylandPlatformWindow::configureBounds(xdg_toplevel *toplevel, int32_t width, int32_t height)
 {
     int32_t w = int32_t(window()->width());

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
@@ -30,7 +30,7 @@ class LinuxWaylandPlatformOutput;
 class KDGUI_API LinuxWaylandPlatformWindow : public AbstractPlatformWindow
 {
 public:
-    explicit LinuxWaylandPlatformWindow(LinuxWaylandPlatformIntegration *platformIntegraton,
+    explicit LinuxWaylandPlatformWindow(LinuxWaylandPlatformIntegration *platformIntegration,
                                         Window *window);
 
     LinuxWaylandPlatformWindow() = delete;

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
@@ -115,6 +115,7 @@ private:
     CursorMode m_cursorMode{ CursorMode::Normal };
     MouseButtons m_mouseButtons{ MouseButton::NoButton };
     std::vector<LinuxWaylandPlatformOutput *> m_enteredOutputs;
+    KDBindings::ScopedConnection m_scaleChangedConnection;
 };
 
 } // namespace KDGui

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
@@ -106,7 +106,8 @@ private:
     void setAppId();
     void updateScaleFactor();
 
-    int32_t scaleByFactor(int32_t value) const;
+    template<typename T>
+    T scaleByFactor(T value) const;
 
     LinuxWaylandPlatformIntegration *m_platformIntegration;
     wl_surface *m_surface{ nullptr };

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
@@ -27,8 +27,7 @@ using namespace KDFoundation;
 using namespace KDGui;
 
 LinuxXcbPlatformEventLoop::LinuxXcbPlatformEventLoop(LinuxXcbPlatformIntegration *platformIntegration)
-    : LinuxPlatformEventLoop()
-    , m_platformIntegration{ platformIntegration }
+    : m_platformIntegration{ platformIntegration }
 {
     m_logger = m_platformIntegration->logger();
 

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
@@ -90,6 +90,7 @@ void LinuxXcbPlatformEventLoop::processXcbEvents()
         switch (eventType) {
         case XCB_EXPOSE: {
             const auto *expose = reinterpret_cast<xcb_expose_event_t *>(xcbEvent);
+            KD_UNUSED(expose); // Silence unused warning in Release build
             SPDLOG_LOGGER_DEBUG(m_logger,
                                 "{}: Window {} exposed. Region to be redrawn at location ({}, {}), with dimension ({}, {})",
                                 xcbEvent->sequence, expose->window, expose->x, expose->y, expose->width, expose->height);
@@ -257,6 +258,7 @@ void LinuxXcbPlatformEventLoop::processXcbEvents()
 
         case XCB_MAP_NOTIFY: {
             const auto *mapEvent = reinterpret_cast<xcb_map_notify_event_t *>(xcbEvent);
+            KD_UNUSED(mapEvent); // Silence unused warning in Release build
             SPDLOG_LOGGER_DEBUG(m_logger,
                                 "Map event for window {}",
                                 mapEvent->window);
@@ -265,6 +267,7 @@ void LinuxXcbPlatformEventLoop::processXcbEvents()
 
         case XCB_UNMAP_NOTIFY: {
             const auto *unmapEvent = reinterpret_cast<xcb_unmap_notify_event_t *>(xcbEvent);
+            KD_UNUSED(unmapEvent); // Silence unused warning in Release build
             SPDLOG_LOGGER_DEBUG(m_logger,
                                 "Unmap event for window {}",
                                 unmapEvent->window);

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_event_loop.cpp
@@ -21,6 +21,8 @@
 
 #include <xcb/xcb.h>
 
+#include <tuple>
+
 using namespace KDFoundation;
 using namespace KDGui;
 
@@ -39,7 +41,7 @@ LinuxXcbPlatformEventLoop::LinuxXcbPlatformEventLoop(LinuxXcbPlatformIntegration
     auto xcbfd = xcb_get_file_descriptor(connection);
     SPDLOG_LOGGER_DEBUG(m_logger, "Registering xcb fd {} with event loop", xcbfd);
     m_xcbNotifier = std::make_unique<FileDescriptorNotifier>(xcbfd, FileDescriptorNotifier::NotificationType::Read);
-    m_xcbNotifier->triggered.connect([this](const int &) {
+    std::ignore = m_xcbNotifier->triggered.connect([this](const int &) {
         this->m_xcbEventsPending = true;
     });
 

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_integration.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_integration.cpp
@@ -122,6 +122,7 @@ bool LinuxXcbPlatformIntegration::initializeXkbExtension()
 
 void LinuxXcbPlatformIntegration::dumpScreenInfo(xcb_screen_t *screen)
 {
+    KD_UNUSED(screen); // for release builds, debug log isn't compiled in
     SPDLOG_DEBUG("Information about screen {}", screen->root);
     SPDLOG_DEBUG("  width.........: {}", screen->width_in_pixels);
     SPDLOG_DEBUG("  height........: {}", screen->height_in_pixels);

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_integration.h
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_integration.h
@@ -53,7 +53,7 @@ private:
     LinuxXcbPlatformWindow *createPlatformWindowImpl(Window *window) override;
 
     bool initializeXkbExtension();
-    void dumpScreenInfo(xcb_screen_t *screen);
+    static void dumpScreenInfo(xcb_screen_t *screen);
 
     std::shared_ptr<spdlog::logger> m_logger;
     xcb_connection_t *m_connection{ nullptr };

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
@@ -42,6 +42,7 @@ bool LinuxXcbPlatformWindow::create()
 
     m_xcbWindow = xcb_generate_id(connection);
     const uint32_t mask = XCB_CW_EVENT_MASK;
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
     const uint32_t values[1] = {
         XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_BUTTON_PRESS |
         XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_POINTER_MOTION |
@@ -169,7 +170,7 @@ void LinuxXcbPlatformWindow::disableCursor()
 
     // Hide the cursor
     const auto connection = m_platformIntegration->connection();
-    uint32_t values[] = { m_hiddenCursor };
+    uint32_t values[] = { m_hiddenCursor }; // NOLINT(modernize-avoid-c-arrays)
     xcb_change_window_attributes(connection, m_xcbWindow, XCB_CURSOR, &values);
 
     // Move cursor to centre of the window
@@ -208,7 +209,7 @@ void LinuxXcbPlatformWindow::enableCursor()
                      int16_t(m_cursorRestorePosition.x), int16_t(m_cursorRestorePosition.y));
 
     // Reset the default cursor (inherit from parent window)
-    uint32_t values[] = { 0 };
+    uint32_t values[] = { 0 }; // NOLINT(modernize-avoid-c-arrays)
     xcb_change_window_attributes(connection, m_xcbWindow, XCB_CURSOR, &values);
     xcb_flush(connection);
 }

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
@@ -41,8 +41,8 @@ bool LinuxXcbPlatformWindow::create()
     const auto screen = m_platformIntegration->screen();
 
     m_xcbWindow = xcb_generate_id(connection);
-    uint32_t mask = XCB_CW_EVENT_MASK;
-    uint32_t values[1] = {
+    const uint32_t mask = XCB_CW_EVENT_MASK;
+    const uint32_t values[1] = {
         XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_BUTTON_PRESS |
         XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_POINTER_MOTION |
         XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW |
@@ -77,10 +77,10 @@ bool LinuxXcbPlatformWindow::create()
     // Register for the WM_DELETE_WINDOW client message events. This prevents the
     // server from disconnecting us when a top-level window is closed. Allows us to
     // just unmap the window gracefully.
-    xcb_intern_atom_cookie_t cookie = xcb_intern_atom(connection, 1, 12, "WM_PROTOCOLS");
-    xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(connection, cookie, nullptr);
-    xcb_intern_atom_cookie_t cookie2 = xcb_intern_atom(connection, 0, 16, "WM_DELETE_WINDOW");
-    xcb_intern_atom_reply_t *reply2 = xcb_intern_atom_reply(connection, cookie2, nullptr);
+    const xcb_intern_atom_cookie_t cookie = xcb_intern_atom(connection, 1, 12, "WM_PROTOCOLS");
+    const xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(connection, cookie, nullptr);
+    const xcb_intern_atom_cookie_t cookie2 = xcb_intern_atom(connection, 0, 16, "WM_DELETE_WINDOW");
+    const xcb_intern_atom_reply_t *reply2 = xcb_intern_atom_reply(connection, cookie2, nullptr);
     m_closeAtom = reply2->atom;
     xcb_change_property(
             connection,
@@ -97,7 +97,7 @@ bool LinuxXcbPlatformWindow::create()
     m_platformIntegration->registerWindowForEvents(m_xcbWindow, this);
 
     // Create a hidden cursor from an unset 1x1 pixmap
-    xcb_pixmap_t pixmap = xcb_generate_id(connection);
+    const xcb_pixmap_t pixmap = xcb_generate_id(connection);
     m_hiddenCursor = xcb_generate_id(connection);
     xcb_create_pixmap(connection, 1, pixmap, screen->root, 1, 1);
     xcb_create_cursor(connection, m_hiddenCursor, pixmap, pixmap,

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
@@ -42,8 +42,7 @@ bool LinuxXcbPlatformWindow::create()
 
     m_xcbWindow = xcb_generate_id(connection);
     const uint32_t mask = XCB_CW_EVENT_MASK;
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-    const uint32_t values[1] = {
+    const std::array<uint32_t, 1> values = {
         XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_BUTTON_PRESS |
         XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_POINTER_MOTION |
         XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW |
@@ -62,7 +61,7 @@ bool LinuxXcbPlatformWindow::create()
             XCB_WINDOW_CLASS_INPUT_OUTPUT, /* class               */
             screen->root_visual, /* visual              */
             mask,
-            values);
+            values.data());
 
     const auto title = m_window->title.get();
     xcb_change_property(
@@ -170,8 +169,8 @@ void LinuxXcbPlatformWindow::disableCursor()
 
     // Hide the cursor
     const auto connection = m_platformIntegration->connection();
-    uint32_t values[] = { m_hiddenCursor }; // NOLINT(modernize-avoid-c-arrays)
-    xcb_change_window_attributes(connection, m_xcbWindow, XCB_CURSOR, &values);
+    const std::array<uint32_t, 1> values = { m_hiddenCursor };
+    xcb_change_window_attributes(connection, m_xcbWindow, XCB_CURSOR, values.data());
 
     // Move cursor to centre of the window
     const auto windowSize = queryWindowSize();
@@ -209,8 +208,8 @@ void LinuxXcbPlatformWindow::enableCursor()
                      int16_t(m_cursorRestorePosition.x), int16_t(m_cursorRestorePosition.y));
 
     // Reset the default cursor (inherit from parent window)
-    uint32_t values[] = { 0 }; // NOLINT(modernize-avoid-c-arrays)
-    xcb_change_window_attributes(connection, m_xcbWindow, XCB_CURSOR, &values);
+    const std::array<uint32_t, 1> values = { 0 };
+    xcb_change_window_attributes(connection, m_xcbWindow, XCB_CURSOR, values.data());
     xcb_flush(connection);
 }
 

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.cpp
@@ -106,7 +106,7 @@ bool LinuxXcbPlatformWindow::create()
                       0, 0, 0, 0);
     xcb_free_pixmap(connection, pixmap);
 
-    if (window()->cursorEnabled.get() == false)
+    if (!window()->cursorEnabled.get())
         disableCursor();
 
     xcb_flush(connection);

--- a/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.h
+++ b/src/KDGui/platform/linux/xcb/linux_xcb_platform_window.h
@@ -24,7 +24,7 @@ class LinuxXcbPlatformIntegration;
 class KDGUI_API LinuxXcbPlatformWindow : public AbstractPlatformWindow
 {
 public:
-    explicit LinuxXcbPlatformWindow(LinuxXcbPlatformIntegration *platformIntegraton,
+    explicit LinuxXcbPlatformWindow(LinuxXcbPlatformIntegration *platformIntegration,
                                     Window *window);
 
     LinuxXcbPlatformWindow() = delete;

--- a/src/KDGui/platform/linux/xcb/linux_xkb_keyboard.cpp
+++ b/src/KDGui/platform/linux/xcb/linux_xkb_keyboard.cpp
@@ -20,6 +20,8 @@
 #include <xcb/xkb.h>
 #undef explicit
 
+#include <array>
+
 using namespace KDGui;
 
 LinuxXkbKeyboard::LinuxXkbKeyboard(LinuxXcbPlatformIntegration *platformIntegration)
@@ -131,9 +133,9 @@ void LinuxXkbKeyboard::handleKeyPress(xcb_key_press_event_t *ev)
     // Update the xkb state
     (void)xkb_state_update_key(m_state.get(), keycode, XKB_KEY_DOWN);
 
-    char s[16];
-    xkb_keysym_get_name(keysym, s, sizeof(s));
-    SPDLOG_LOGGER_TRACE(m_logger, "keysym: {} => name: {}", keysym, s);
+    std::array<char, 16> s;
+    xkb_keysym_get_name(keysym, s.data(), s.size());
+    SPDLOG_LOGGER_TRACE(m_logger, "keysym: {} => name: {}", keysym, s.data());
 
     // Lookup the KDGui key enum
     auto key = xkb::keysymToKey(keysym);
@@ -145,9 +147,9 @@ void LinuxXkbKeyboard::handleKeyPress(xcb_key_press_event_t *ev)
     window->handleKeyPress(ev->time, ev->detail, key, modifiers);
 
     // Get the unicode characters
-    xkb_state_key_get_utf8(m_state.get(), keycode, s, sizeof(s));
-    if (strlen(s) > 0)
-        window->handleTextInput(s);
+    xkb_state_key_get_utf8(m_state.get(), keycode, s.data(), s.size());
+    if (strlen(s.data()) > 0)
+        window->handleTextInput(s.data());
 }
 
 void LinuxXkbKeyboard::handleKeyRelease(xcb_key_release_event_t *ev)
@@ -162,9 +164,9 @@ void LinuxXkbKeyboard::handleKeyRelease(xcb_key_release_event_t *ev)
     // Update the xkb state
     (void)xkb_state_update_key(m_state.get(), keycode, XKB_KEY_UP);
 
-    char s[16];
-    xkb_keysym_get_name(keysym, s, sizeof(s));
-    SPDLOG_LOGGER_TRACE(m_logger, "keysym: {} => name: {}", keysym, s);
+    std::array<char, 16> s;
+    xkb_keysym_get_name(keysym, s.data(), s.size());
+    SPDLOG_LOGGER_TRACE(m_logger, "keysym: {} => name: {}", keysym, s.data());
 
     // Lookup the KDGui key enum
     auto key = xkb::keysymToKey(keysym);

--- a/src/KDGui/window.cpp
+++ b/src/KDGui/window.cpp
@@ -16,6 +16,8 @@
 #include <KDFoundation/platform/abstract_platform_integration.h>
 #include <KDFoundation/event.h>
 
+#include <tuple>
+
 using namespace KDFoundation;
 using namespace KDGui;
 
@@ -24,13 +26,13 @@ Window::Window()
     , m_logger{ KDUtils::Logger::logger("window", spdlog::level::info) }
 {
 
-    visible.valueChanged().connect(&Window::onVisibleChanged, this);
+    std::ignore = visible.valueChanged().connect(&Window::onVisibleChanged, this);
     m_resizeConnectionIds = {
         width.valueChanged().connect(&Window::onSizeChanged, this),
         height.valueChanged().connect(&Window::onSizeChanged, this)
     };
-    cursorEnabled.valueChanged().connect(&Window::onCursorEnabledChanged, this);
-    rawMouseInputEnabled.valueChanged().connect(&Window::onRawMouseInputEnabledChanged, this);
+    std::ignore = cursorEnabled.valueChanged().connect(&Window::onCursorEnabledChanged, this);
+    std::ignore = rawMouseInputEnabled.valueChanged().connect(&Window::onRawMouseInputEnabledChanged, this);
 }
 
 Window::~Window()

--- a/src/KDGui/window.cpp
+++ b/src/KDGui/window.cpp
@@ -224,6 +224,7 @@ void Window::resizeEvent(ResizeEvent *ev)
 
 void Window::mousePressEvent(MousePressEvent *ev)
 {
+    KD_UNUSED(ev); // for release builds, debug log isn't compiled in
     SPDLOG_LOGGER_DEBUG(m_logger,
                         "{}() buttons = {} at pos = ({}, {})",
                         __FUNCTION__,
@@ -234,6 +235,7 @@ void Window::mousePressEvent(MousePressEvent *ev)
 
 void Window::mouseReleaseEvent(MouseReleaseEvent *ev)
 {
+    KD_UNUSED(ev); // for release builds, debug log isn't compiled in
     SPDLOG_LOGGER_DEBUG(m_logger,
                         "{}() buttons = {} at pos = ({}, {})",
                         __FUNCTION__,
@@ -244,6 +246,7 @@ void Window::mouseReleaseEvent(MouseReleaseEvent *ev)
 
 void Window::mouseMoveEvent(MouseMoveEvent *ev)
 {
+    KD_UNUSED(ev); // for release builds, debug log isn't compiled in
     SPDLOG_LOGGER_DEBUG(m_logger,
                         "{}() buttons = {} at pos = ({}, {})",
                         __FUNCTION__,
@@ -254,6 +257,7 @@ void Window::mouseMoveEvent(MouseMoveEvent *ev)
 
 void Window::mouseWheelEvent(MouseWheelEvent *ev)
 {
+    KD_UNUSED(ev); // for release builds, debug log isn't compiled in
     SPDLOG_LOGGER_DEBUG(m_logger,
                         "{}() xDelta = {} yDelta = {}",
                         __FUNCTION__,
@@ -263,10 +267,12 @@ void Window::mouseWheelEvent(MouseWheelEvent *ev)
 
 void Window::keyPressEvent(KeyPressEvent *ev)
 {
+    KD_UNUSED(ev); // for release builds, debug log isn't compiled in
     SPDLOG_LOGGER_DEBUG(m_logger, "{}() key = {}", __FUNCTION__, ev->key());
 }
 
 void Window::keyReleaseEvent(KeyReleaseEvent *ev)
 {
+    KD_UNUSED(ev); // for release builds, debug log isn't compiled in
     SPDLOG_LOGGER_DEBUG(m_logger, "{}() key = {}", __FUNCTION__, ev->key());
 }

--- a/src/KDGui/window.cpp
+++ b/src/KDGui/window.cpp
@@ -22,8 +22,7 @@ using namespace KDFoundation;
 using namespace KDGui;
 
 Window::Window()
-    : Object()
-    , m_logger{ KDUtils::Logger::logger("window", spdlog::level::info) }
+    : m_logger{ KDUtils::Logger::logger("window", spdlog::level::info) }
 {
 
     std::ignore = visible.valueChanged().connect(&Window::onVisibleChanged, this);

--- a/src/KDGui/window.cpp
+++ b/src/KDGui/window.cpp
@@ -210,12 +210,12 @@ void Window::resizeEvent(ResizeEvent *ev)
                         ev->height());
     // Block internal connection to onSizeChanged() to avoid a loop
     {
-        KDBindings::ConnectionBlocker widthBlocker{ m_resizeConnectionIds[0] };
+        const KDBindings::ConnectionBlocker widthBlocker{ m_resizeConnectionIds[0] };
         width = ev->width();
     }
 
     {
-        KDBindings::ConnectionBlocker heightBlocker{ m_resizeConnectionIds[1] };
+        const KDBindings::ConnectionBlocker heightBlocker{ m_resizeConnectionIds[1] };
         height = ev->height();
     }
 

--- a/src/KDUtils/bytearray.cpp
+++ b/src/KDUtils/bytearray.cpp
@@ -83,7 +83,7 @@ ByteArray ByteArray::mid(size_t pos, size_t len) const
     if (len == 0)
         len = size() - pos;
     len = std::min(len, size());
-    return ByteArray({ m_data.begin() + pos, m_data.begin() + int64_t(pos + len) });
+    return ByteArray({ m_data.begin() + int64_t(pos), m_data.begin() + int64_t(pos + len) });
 }
 
 ByteArray ByteArray::left(size_t left) const
@@ -105,7 +105,7 @@ ByteArray &ByteArray::remove(size_t pos, size_t len)
     if (pos >= size())
         return *this;
     len = std::min(size() - pos, len);
-    m_data.erase(m_data.begin() + pos, m_data.begin() + int64_t(pos + len));
+    m_data.erase(m_data.begin() + int64_t(pos), m_data.begin() + int64_t(pos + len));
     return *this;
 }
 

--- a/src/KDUtils/file.cpp
+++ b/src/KDUtils/file.cpp
@@ -152,7 +152,7 @@ void File::write(const ByteArray &data)
 
 std::string File::fileName() const
 {
-    std::filesystem::path p(m_path);
+    const std::filesystem::path p(m_path);
     return p.filename().u8string();
 }
 

--- a/src/KDUtils/file_mapper.cpp
+++ b/src/KDUtils/file_mapper.cpp
@@ -21,7 +21,7 @@ using WriteMap = mio::basic_mmap<mio::access_mode::write, uint8_t>;
 struct FileMapper::Map {
     std::variant<ReadMap, WriteMap> map;
 
-    ~Map() {};
+    ~Map() { }
 
     Map(bool writeable)
     {

--- a/src/KDUtils/file_mapper.cpp
+++ b/src/KDUtils/file_mapper.cpp
@@ -12,7 +12,7 @@
 #include <KDUtils/file_mapper.h>
 #include <spdlog/spdlog.h>
 #include <variant>
-#include <mio/mmap.hpp>
+#include <mio/mmap.hpp> // NOLINT(misc-header-include-cycle)
 
 namespace KDUtils {
 using ReadMap = mio::basic_mmap<mio::access_mode::read, uint8_t>;

--- a/src/KDUtils/file_mapper.cpp
+++ b/src/KDUtils/file_mapper.cpp
@@ -21,9 +21,9 @@ using WriteMap = mio::basic_mmap<mio::access_mode::write, uint8_t>;
 struct FileMapper::Map {
     std::variant<ReadMap, WriteMap> map;
 
-    inline ~Map() {};
+    ~Map() {};
 
-    inline Map(bool writeable)
+    Map(bool writeable)
     {
         // NOTE: mio's maps consist of primitive types which won't throw. but
         // the constructors are not marked noexcept
@@ -33,17 +33,17 @@ struct FileMapper::Map {
             map = ReadMap();
     }
 
-    [[nodiscard]] inline bool writable() const noexcept
+    [[nodiscard]] bool writable() const noexcept
     {
         return std::holds_alternative<WriteMap>(map);
     }
 
-    inline WriteMap &writableMap()
+    WriteMap &writableMap()
     {
         return std::get<WriteMap>(map);
     }
 
-    inline ReadMap &readOnlyMap()
+    ReadMap &readOnlyMap()
     {
         return std::get<ReadMap>(map);
     }

--- a/src/KDUtils/file_mapper.cpp
+++ b/src/KDUtils/file_mapper.cpp
@@ -60,8 +60,9 @@ FileMapper::FileMapper(File &&file)
 // a default deleter without knowing the size of the type.
 FileMapper::~FileMapper() = default;
 
+namespace {
 template<std::ios::openmode mode>
-static const uint8_t *mapImpl(
+const uint8_t *mapImpl(
         std::unique_ptr<FileMapper::Map> &output,
         const std::string &path,
         std::uintmax_t offset,
@@ -108,6 +109,7 @@ static const uint8_t *mapImpl(
         return output->readOnlyMap().data();
     }
 }
+} // namespace
 
 const uint8_t *FileMapper::map(std::uintmax_t offset, std::uintmax_t length) const
 {

--- a/src/KDUtils/url.cpp
+++ b/src/KDUtils/url.cpp
@@ -20,7 +20,7 @@ namespace KDUtils {
 Url::Url(const std::string &url)
     : m_url(url)
 {
-    std::regex rexExp(u8"(?:([^\\/]{2,})?:(?:\\/\\/)?)?(.*\\/)*(.+\\..+)?"s);
+    const std::regex rexExp(u8"(?:([^\\/]{2,})?:(?:\\/\\/)?)?(.*\\/)*(.+\\..+)?"s);
     std::smatch match;
     const bool hasMatch = std::regex_match(m_url, match, rexExp);
     if (hasMatch) {

--- a/tests/auto/foundation/common/signal_spy.h
+++ b/tests/auto/foundation/common/signal_spy.h
@@ -23,7 +23,7 @@ public:
     template<typename Signal>
     explicit SignalSpy(Signal &s)
     {
-        s.connect([this](Args... args) {
+        m_connection = s.connect([this](Args... args) {
             callback(args...);
         });
     }
@@ -74,4 +74,5 @@ private:
 
     uint32_t m_count = 0;
     std::tuple<Args...> m_args;
+    KDBindings::ScopedConnection m_connection;
 };

--- a/tests/auto/foundation/core_application/tst_core_application.cpp
+++ b/tests/auto/foundation/core_application/tst_core_application.cpp
@@ -18,6 +18,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <tuple>
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest.h>
@@ -203,7 +204,7 @@ TEST_CASE("Timer handling")
         int timeout = 0;
         auto startTime = std::chrono::steady_clock::now();
         auto time = startTime;
-        timer.timeout.connect([&]() {
+        std::ignore = timer.timeout.connect([&]() {
             const auto endTime = std::chrono::steady_clock::now();
             REQUIRE(endTime - time > 50ms);
             REQUIRE(endTime - time < 150ms);
@@ -240,7 +241,7 @@ TEST_CASE("Timer handling")
 
         bool fired = false;
 
-        timer.timeout.connect([&] {
+        std::ignore = timer.timeout.connect([&] {
             fired = true;
         });
 

--- a/tests/auto/foundation/object/tst_object.cpp
+++ b/tests/auto/foundation/object/tst_object.cpp
@@ -19,6 +19,7 @@
 
 #include <numeric>
 #include <string>
+#include <tuple>
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest.h>
@@ -288,7 +289,7 @@ TEST_CASE("Object destruction")
 
         for (int i = 0; i < 10; ++i) {
             auto child = parent->createChild<IntObject>(i);
-            child->aboutToBeDestroyed.connect(onAboutToBeDestroyed);
+            std::ignore = child->aboutToBeDestroyed.connect(onAboutToBeDestroyed);
         }
         // THEN
         REQUIRE(childRemovedSpy.count() == 0);

--- a/tests/auto/foundation/win32_platform_event_loop/tst_win32_platform_event_loop.cpp
+++ b/tests/auto/foundation/win32_platform_event_loop/tst_win32_platform_event_loop.cpp
@@ -25,6 +25,7 @@
 #include <numeric>
 #include <string>
 #include <thread>
+#include <tuple>
 
 #include <WinSock2.h>
 #include <WS2tcpip.h>
@@ -185,7 +186,7 @@ TEST_CASE("Wait for events")
         // A notifier for testing deregistration
         int unregisteredCalls = 0;
         FileDescriptorNotifier unregistered(clientSock, FileDescriptorNotifier::NotificationType::Read);
-        unregistered.triggered.connect([&unregisteredCalls] {
+        std::ignore = unregistered.triggered.connect([&unregisteredCalls] {
             unregisteredCalls++;
         });
         loop.registerNotifier(&unregistered);
@@ -193,7 +194,7 @@ TEST_CASE("Wait for events")
 
         // Set up read notifier to receive the data
         FileDescriptorNotifier readNotifier(clientSock, FileDescriptorNotifier::NotificationType::Read);
-        readNotifier.triggered.connect([&dataReceived](int fd) {
+        std::ignore = readNotifier.triggered.connect([&dataReceived](int fd) {
             char buf[128] = {};
             recv(fd, buf, 128, 0);
             const int recvSize = recv(fd, buf, 128, 0);
@@ -205,7 +206,7 @@ TEST_CASE("Wait for events")
         // A notifier for testing Write notification type
         FileDescriptorNotifier writeNotifier(clientSock, FileDescriptorNotifier::NotificationType::Write);
         int writeTriggered = 0;
-        writeNotifier.triggered.connect([&writeTriggered]() {
+        std::ignore = writeNotifier.triggered.connect([&writeTriggered]() {
             writeTriggered++;
         });
         loop.registerNotifier(&writeNotifier);

--- a/tests/auto/utils/signal/tst_signal.cpp
+++ b/tests/auto/utils/signal/tst_signal.cpp
@@ -14,6 +14,7 @@
 #include <kdbindings/signal.h>
 
 #include <thread>
+#include <tuple>
 
 using namespace KDUtils;
 
@@ -31,13 +32,13 @@ TEST_SUITE("Signal")
         KDBindings::Signal<int> signal2;
 
         std::thread thread1([&] {
-            signal1.connectDeferred(app.connectionEvaluator(), [&val](int value) {
+            std::ignore = signal1.connectDeferred(app.connectionEvaluator(), [&val](int value) {
                 val += value;
             });
         });
 
         std::thread thread2([&] {
-            signal2.connectDeferred(app.connectionEvaluator(), [&val](int value) {
+            std::ignore = signal2.connectDeferred(app.connectionEvaluator(), [&val](int value) {
                 val += value;
             });
         });
@@ -91,11 +92,11 @@ TEST_SUITE("Signal")
         int val1 = 4;
         int val2 = 4;
 
-        signal1.connectDeferred(app.connectionEvaluator(), [&val1](int value) {
+        std::ignore = signal1.connectDeferred(app.connectionEvaluator(), [&val1](int value) {
             val1 += value;
         });
 
-        signal2.connectDeferred(app.connectionEvaluator(), [&val2](int value) {
+        std::ignore = signal2.connectDeferred(app.connectionEvaluator(), [&val2](int value) {
             val2 += value;
         });
 


### PR DESCRIPTION
This is a giant PR but it's comprised of (mostly) small atomic commits. So best reviewed commit by commit.

Not _everything_ is fixed yet. Few more complicated ones are left out. Also, fixing warnings in tests will be done separately.