### PR TITLE
Rename and fix workflow

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-name: Nightly
+name: Linters
 
 on:
   schedule:
@@ -26,7 +26,7 @@ jobs:
             tidy-executable: clang-tidy-18
           - name: Windows
             os: windows-2022
-            tidy-executble: clang-tidy
+            tidy-executable: clang-tidy
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Rename nightly → linters as it better descrbies what it does, plus, we'll probably run it on pull requests later.

Fixed typo in matrix property name which prevented clang-tidy from running on Windows.