### PR TITLE
Fix test compile warning

### DIFF
--- a/tests/auto/foundation/linux_platform_event_loop/tst_linux_platform_event_loop.cpp
+++ b/tests/auto/foundation/linux_platform_event_loop/tst_linux_platform_event_loop.cpp
@@ -22,6 +22,7 @@
 #include <numeric>
 #include <string>
 #include <thread>
+#include <tuple>
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest.h>
@@ -396,7 +397,7 @@ TEST_CASE("Notifies about events")
         // Register a notifier to listen to the read end of the pipe
         auto notifier1 = std::make_unique<FileDescriptorNotifier>(pipe1[0], FileDescriptorNotifier::NotificationType::Read);
         bool notified = false;
-        notifier1->triggered.connect([&notified](const int &) {
+        std::ignore = notifier1->triggered.connect([&notified](const int &) {
             SPDLOG_INFO("Notifier has been triggered");
             notified = true;
         });


### PR DESCRIPTION
Fixes this warning:
```
KDUtils/tests/auto/foundation/linux_platform_event_loop/tst_linux_platform_event_loop.cpp: In function ‘void DOCTEST_ANON_FUNC_38()’:
KDUtils/tests/auto/foundation/linux_platform_event_loop/tst_linux_platform_event_loop.cpp:402:11: warning: ignoring return value of ‘KDBindings::ConnectionHandle KDBindings::Signal<Args>::connect(const std::function<void(Args ...)>&) [with Args = {int}]’, declared with attribute ‘nodiscard’ [-Wunused-result]
  402 |         });
      |           ^
In file included from KDUtils/src/KDUtils/../KDFoundation/object.h:21,
                 from KDUtils/src/KDUtils/../KDFoundation/file_descriptor_notifier.h:14,
                 from KDUtils/src/KDUtils/../KDFoundation/platform/linux/linux_platform_event_loop.h:15,
                 from KDUtils/tests/auto/foundation/linux_platform_event_loop/tst_linux_platform_event_loop.cpp:12:
KDUtils/build/_deps/kdbindings-src/src/kdbindings/../kdbindings/signal.h:337:45: note: declared here
  337 |     KDBINDINGS_WARN_UNUSED ConnectionHandle connect(std::function<void(Args...)> const &slot)
      |                                             ^~~~~~~
```