### PR TITLE
wayland: guard accesses to PlatformWindow in PlatformInput

### DIFF
--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_input.h
@@ -109,21 +109,21 @@ private:
         zwp_relative_pointer_v1 *relativePointerV1{ nullptr };
         zwp_locked_pointer_v1 *lockedPointerV1{ nullptr };
         wl_surface *cursorSurface{ nullptr };
-        LinuxWaylandPlatformWindow *focus{ nullptr };
+        wl_surface *focus{ nullptr };
         Position pos{ 0, 0 };
         struct AccumulatedPointerEvent {
             uint32_t time{ 0 };
             Position axis{ 0, 0 };
             Position pos{ 0, 0 };
             Position delta{ 0, 0 };
-            LinuxWaylandPlatformWindow *focus{ nullptr };
+            wl_surface *focus{ nullptr };
             int focusChange : 1;
         } accumulatedEvent;
     } m_pointer;
 
     struct Keyboard {
         wl_keyboard *keyboard{ nullptr };
-        LinuxWaylandPlatformWindow *focus{ nullptr };
+        wl_surface *focus{ nullptr };
         xkb_context *context{ nullptr };
         xkb_keymap *keymap{ nullptr };
         xkb_state *state{ nullptr };
@@ -143,7 +143,7 @@ private:
 
     struct Touch {
         wl_touch *touch{ nullptr };
-        LinuxWaylandPlatformWindow *focus{ nullptr };
+        wl_surface *focus{ nullptr };
         uint32_t time{ 0 };
         struct Point {
             int32_t id;

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
@@ -113,6 +113,14 @@ AbstractClipboard *LinuxWaylandPlatformIntegration::clipboard()
     return m_clipboard.get();
 }
 
+LinuxWaylandPlatformWindow *LinuxWaylandPlatformIntegration::window(wl_surface *surface) const
+{
+    const auto it = m_windows.find(surface);
+    if (it == m_windows.end())
+        return nullptr;
+    return it->second;
+}
+
 LinuxWaylandPlatformEventLoop *LinuxWaylandPlatformIntegration::createPlatformEventLoopImpl()
 {
     return new LinuxWaylandPlatformEventLoop(this);

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 
 #include <KDGui/abstract_gui_platform_integration.h>
@@ -69,6 +70,13 @@ public:
 
     wl_cursor_theme *cursorTheme() const { return m_cursorTheme; }
 
+    void registerWindowForEvents(wl_surface *surface, LinuxWaylandPlatformWindow *window)
+    {
+        m_windows.insert({ surface, window });
+    }
+    void unregisterWindowForEvents(wl_surface *surface) { m_windows.erase(surface); }
+    LinuxWaylandPlatformWindow *window(wl_surface *surface) const;
+
 private:
     LinuxWaylandPlatformEventLoop *createPlatformEventLoopImpl() override;
     LinuxWaylandPlatformWindow *createPlatformWindowImpl(Window *window) override;
@@ -91,6 +99,7 @@ private:
     Global<zxdg_decoration_manager_v1> m_decorationV1;
     Global<wl_data_device_manager> m_dataDeviceManager;
 
+    std::unordered_map<wl_surface *, LinuxWaylandPlatformWindow *> m_windows;
     std::vector<std::unique_ptr<LinuxWaylandPlatformInput>> m_inputs;
     std::vector<std::unique_ptr<LinuxWaylandPlatformOutput>> m_outputs;
     wl_cursor_theme *m_cursorTheme{ nullptr };

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.cpp
@@ -47,13 +47,6 @@ LinuxWaylandPlatformWindow::LinuxWaylandPlatformWindow(
     });
 }
 
-LinuxWaylandPlatformWindow *LinuxWaylandPlatformWindow::fromSurface(wl_surface *surface)
-{
-    auto w = static_cast<LinuxWaylandPlatformWindow *>(wl_surface_get_user_data(surface));
-    assert(w);
-    return w;
-}
-
 wl_display *LinuxWaylandPlatformWindow::display() const
 {
     return m_platformIntegration->display();
@@ -65,6 +58,7 @@ bool LinuxWaylandPlatformWindow::create()
         return true;
 
     m_surface = wl_compositor_create_surface(m_platformIntegration->compositor().object);
+    m_platformIntegration->registerWindowForEvents(m_surface, this);
     static const wl_surface_listener listener = {
         wrapWlCallback<&LinuxWaylandPlatformWindow::enter>,
         wrapWlCallback<&LinuxWaylandPlatformWindow::leave>
@@ -81,6 +75,8 @@ bool LinuxWaylandPlatformWindow::destroy()
     if (m_surface) {
         wl_surface_destroy(m_surface);
     }
+    m_platformIntegration->unregisterWindowForEvents(m_surface);
+    m_surface = nullptr;
     return true;
 }
 

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_window.h
@@ -41,7 +41,6 @@ public:
     LinuxWaylandPlatformWindow(LinuxWaylandPlatformWindow &&other) noexcept = default;
     LinuxWaylandPlatformWindow &operator=(LinuxWaylandPlatformWindow &&other) noexcept = default;
 
-    static LinuxWaylandPlatformWindow *fromSurface(wl_surface *surface);
     inline wl_surface *surface() const { return m_surface; }
     wl_display *display() const;
 


### PR DESCRIPTION
The event queue isn't always empty after closing a window. This caused a crash in some cases where the input handler tried to access a destroyed window.

Usual case:
```
virtual bool KDGui::LinuxWaylandPlatformWindow::destroy()                                 ← window closed
virtual KDGui::LinuxWaylandPlatformWindow::~LinuxWaylandPlatformWindow()                  ← platform window destroyed
void KDGui::LinuxWaylandPlatformInput::pointerLeave(wl_pointer*, uint32_t, wl_surface*)   ← sets m_pointer.accumulatedEvent.focus = nullptr
void KDGui::LinuxWaylandPlatformInput::pointerFrame(wl_pointer*)                          ← doesn't crash because m_pointer.accumulatedEvent.focus == nullptr
KDGui::LinuxWaylandPlatformInput::~LinuxWaylandPlatformInput()
void KDGui::LinuxWaylandPlatformInput::destroyPointer()
```

Sometimes:
```
virtual bool KDGui::LinuxWaylandPlatformWindow::destroy()                                 ← window closed
virtual KDGui::LinuxWaylandPlatformWindow::~LinuxWaylandPlatformWindow()                  ← platform window destroyed
void KDGui::LinuxWaylandPlatformInput::pointerMotion(...)                                 ← \
void KDGui::LinuxWaylandPlatformInput::pointerRelativeMotionV1(...)                       ←  | some pointer events are handled later, used to crash trying to use the platform window
void KDGui::LinuxWaylandPlatformInput::pointerFrame(wl_pointer*)                          ← /
void KDGui::LinuxWaylandPlatformInput::pointerLeave(wl_pointer*, uint32_t, wl_surface*)   ← sets m_pointer.accumulatedEvent.focus = nullptr
void KDGui::LinuxWaylandPlatformInput::pointerFrame(wl_pointer*)                          ← OK
KDGui::LinuxWaylandPlatformInput::~LinuxWaylandPlatformInput()
void KDGui::LinuxWaylandPlatformInput::destroyPointer()
```

This implements the same pattern as the XCB integration by keeping a map of the available windows in the main integration class. Instead of storing raw pointers to the focussed platform window in the input handler, we only keep the wl_surface pointers and go through the map to check if the window is still alive.

Task-Id: TOY-65
Change-Id: Ibaabe657aa87b7f481b9eda5525eceb3813f1c6d