### PR TITLE
Enable linters workflow on PRs and disable nightly

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,9 +5,8 @@
 name: Linters
 
 on:
-  schedule:
-    - cron: '37 21 * * *'
   workflow_dispatch:
+  pull_request:
 
 env:
   CC: "clang"


### PR DESCRIPTION
I think that nightly is not really needed if we have it for PRs. Plus
I left the manual dispatch so that we can start it as needed.