### PR TITLE
Switch pre-commit to markdownlint-cli2

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,16 @@
+{
+    "default": true,
+    "MD007": {
+        "indent": 2,
+        "start_indented": false
+    },
+    "MD013": {
+        "line_length": 100,
+        "tables": false,
+        "code_blocks": false
+    },
+    "MD029": {
+        "style": "ordered"
+    },
+    "MD033": false
+}

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,0 @@
-style ".mdlrc.rb"

--- a/.mdlrc.rb
+++ b/.mdlrc.rb
@@ -1,5 +1,0 @@
-all
-rule 'MD007', :indent => 2, :start_indented => false
-rule 'MD013', :line_length => 100, :tables => false, :ignore_code_blocks => true
-rule 'MD029', :style => :ordered
-exclude_rule 'MD033'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,13 +26,11 @@ repos:
   hooks:
   - id: cmake-lint
   - id: cmake-format
-- repo: https://github.com/markdownlint/markdownlint
-  rev: v0.12.0
+- repo: https://github.com/DavidAnson/markdownlint-cli2
+  rev: v0.13.0
   hooks:
-  - id: markdownlint
-    entry: mdl
+  - id: markdownlint-cli2
     exclude: ^(3rdParty/|common/ui/resources/licenses/)
-    language: ruby
     files: \.(md|mdown|markdown)$
 - repo: https://github.com/fsfe/reuse-tool
   rev: v4.0.3

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -14,7 +14,7 @@ Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc config files
-Files: .pre-commit-config.yaml .codespellrc .krazy .cmake-format .clang-format .clang-tidy .gitignore .gitreview .mdlrc .mdlrc.rb appveyor.yml
+Files: .pre-commit-config.yaml .codespellrc .krazy .cmake-format .clang-format .clang-tidy .gitignore .gitreview .markdownlint.jsonc appveyor.yml
 Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: BSD-3-Clause
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo apt install gcovr
 ## Contact
 
 - Visit us on GitHub: <https://github.com/KDAB/KDUtils>
-- Email info@kdab.com for questions about copyright, licensing or commercial support.
+- Email <info@kdab.com> for questions about copyright, licensing or commercial support.
 
 ## Licensing
 
@@ -78,7 +78,7 @@ Contact KDAB at <info@kdab.com> to inquire about commercial licensing.
 Please submit your contributions or issue reports from our GitHub space at
 <https://github.com/KDAB/KDUtils>.
 
-Contact info@kdab.com for more information.
+Contact <info@kdab.com> for more information.
 
 ## About KDAB
 


### PR DESCRIPTION
It doesn't require Ruby and works out of the box on Windows. Original markdownlint wasn't able to install Ruby properly on Windows.

Fixed a newly found issue in README as well.