### PR TITLE
Fix win32 socket test

### DIFF
--- a/tests/auto/foundation/win32_platform_event_loop/tst_win32_platform_event_loop.cpp
+++ b/tests/auto/foundation/win32_platform_event_loop/tst_win32_platform_event_loop.cpp
@@ -232,7 +232,7 @@ TEST_CASE("Wait for events")
         REQUIRE_MESSAGE(dataReceived == dataToSend, "Data sent doesn't match the data received");
 
         closesocket(clientSock);
-        WSACleanup();
         serverThread.join();
+        WSACleanup();
     }
 }


### PR DESCRIPTION
We should first join the server thread an only then do the WSACleanup() as closesocket() in server thread may be called after WSACleanup() if we don't join first.