### PR TITLE
Fix formatting under clang-format >=19.1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,3 +34,4 @@ BraceWrapping:
     IndentBraces: false
 
 CommentPragmas:  '/\*(.+\n.+)+\*/'
+AttributeMacros: [KDFOUNDATION_API, KDGUI_API, KDUTILS_EXPORT]


### PR DESCRIPTION
After pre-commit bumped our clang-format to 19.1.0 it started formatting some files differently (and incorrectly).

It turns out it's due to missing AttributeMacros config. Previous clang-format versions were more lenient about it.

See https://github.com/llvm/llvm-project/issues/94184 and https://github.com/KDAB/KDUtils/pull/37