### PR TITLE
Unify export macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,4 +34,4 @@ BraceWrapping:
     IndentBraces: false
 
 CommentPragmas:  '/\*(.+\n.+)+\*/'
-AttributeMacros: [KDFOUNDATION_API, KDGUI_API, KDUTILS_EXPORT]
+AttributeMacros: [KDFOUNDATION_API, KDGUI_API, KDUTILS_API]

--- a/src/KDUtils/bytearray.h
+++ b/src/KDUtils/bytearray.h
@@ -16,11 +16,11 @@
 #include <cstdint>
 #include <string>
 
-#include <KDUtils/kdutils_export.h>
+#include <KDUtils/kdutils_global.h>
 
 namespace KDUtils {
 
-class KDUTILS_EXPORT ByteArray
+class KDUTILS_API ByteArray
 {
 public:
     ByteArray();
@@ -69,9 +69,9 @@ private:
     std::vector<uint8_t> m_data;
 };
 
-KDUTILS_EXPORT bool operator==(const ByteArray &a, const ByteArray &b);
-KDUTILS_EXPORT bool operator!=(const ByteArray &a, const ByteArray &b);
-KDUTILS_EXPORT ByteArray operator+(const ByteArray &a, const ByteArray &b);
+KDUTILS_API bool operator==(const ByteArray &a, const ByteArray &b);
+KDUTILS_API bool operator!=(const ByteArray &a, const ByteArray &b);
+KDUTILS_API ByteArray operator+(const ByteArray &a, const ByteArray &b);
 
 } // namespace KDUtils
 

--- a/src/KDUtils/dir.h
+++ b/src/KDUtils/dir.h
@@ -12,13 +12,13 @@
 #ifndef KDUTILS_DIR_H
 #define KDUTILS_DIR_H
 
-#include <KDUtils/kdutils_export.h>
+#include <KDUtils/kdutils_global.h>
 #include <string>
 #include <filesystem>
 
 namespace KDUtils {
 
-class KDUTILS_EXPORT Dir
+class KDUTILS_API Dir
 {
 public:
     Dir();

--- a/src/KDUtils/elapsedtimer.h
+++ b/src/KDUtils/elapsedtimer.h
@@ -12,13 +12,13 @@
 #ifndef KDUTILS_ELAPSEDTIMER_H
 #define KDUTILS_ELAPSEDTIMER_H
 
-#include <KDUtils/kdutils_export.h>
+#include <KDUtils/kdutils_global.h>
 #include <chrono>
 #include <ratio>
 
 namespace KDUtils {
 
-class KDUTILS_EXPORT ElapsedTimer
+class KDUTILS_API ElapsedTimer
 {
 public:
     using Clock = std::chrono::high_resolution_clock;

--- a/src/KDUtils/file.h
+++ b/src/KDUtils/file.h
@@ -11,7 +11,7 @@
 #ifndef KDUTILS_FILE_H
 #define KDUTILS_FILE_H
 
-#include <KDUtils/kdutils_export.h>
+#include <KDUtils/kdutils_global.h>
 #include <KDUtils/bytearray.h>
 #include <iostream>
 #include <fstream>
@@ -23,7 +23,7 @@
 
 namespace KDUtils {
 
-class KDUTILS_EXPORT File
+class KDUTILS_API File
 {
 public:
     File(const std::string &path);
@@ -60,7 +60,7 @@ private:
 };
 
 #if defined(ANDROID)
-KDUTILS_EXPORT void setAssetManager(AAssetManager *assetManager);
+KDUTILS_API void setAssetManager(AAssetManager *assetManager);
 #endif
 
 } // namespace KDUtils

--- a/src/KDUtils/file_mapper.h
+++ b/src/KDUtils/file_mapper.h
@@ -11,11 +11,11 @@
 #ifndef KDUTILS_FILE_MAPPER_H
 #define KDUTILS_FILE_MAPPER_H
 #include <KDUtils/file.h>
-#include <KDUtils/kdutils_export.h>
+#include <KDUtils/kdutils_global.h>
 
 namespace KDUtils {
 /// Provides memory mapping from a file.
-class KDUTILS_EXPORT FileMapper
+class KDUTILS_API FileMapper
 {
 public:
     struct Map;

--- a/src/KDUtils/kdutils_global.h
+++ b/src/KDUtils/kdutils_global.h
@@ -11,4 +11,8 @@
 
 #pragma once
 
+#include <KDUtils/kdutils_export.h>
+
+#define KDUTILS_API KDUTILS_EXPORT
+
 #define KD_UNUSED(x) (void)x;

--- a/src/KDUtils/logging.h
+++ b/src/KDUtils/logging.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <KDUtils/kdutils_export.h>
+#include <KDUtils/kdutils_global.h>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -19,7 +19,7 @@
 
 namespace KDUtils {
 
-class KDUTILS_EXPORT Logger
+class KDUTILS_API Logger
 {
 public:
     static std::shared_ptr<spdlog::logger> logger(const std::string &name, spdlog::level::level_enum defaultLevel = spdlog::level::warn);

--- a/src/KDUtils/url.cpp
+++ b/src/KDUtils/url.cpp
@@ -78,12 +78,12 @@ Url Url::fromLocalFile(const std::string &url)
     return Url(std::string("file://") + path);
 }
 
-KDUTILS_EXPORT bool operator==(const Url &a, const Url &b)
+bool operator==(const Url &a, const Url &b)
 {
     return a.url() == b.url();
 }
 
-KDUTILS_EXPORT bool operator!=(const Url &a, const Url &b)
+bool operator!=(const Url &a, const Url &b)
 {
     return !(a == b);
 }

--- a/src/KDUtils/url.h
+++ b/src/KDUtils/url.h
@@ -12,12 +12,12 @@
 #ifndef KDUTILS_URL_H
 #define KDUTILS_URL_H
 
-#include <KDUtils/kdutils_export.h>
+#include <KDUtils/kdutils_global.h>
 #include <string>
 
 namespace KDUtils {
 
-class KDUTILS_EXPORT Url
+class KDUTILS_API Url
 {
 public:
     Url() = default;
@@ -41,8 +41,8 @@ private:
     std::string m_path;
 };
 
-KDUTILS_EXPORT bool operator==(const Url &a, const Url &b);
-KDUTILS_EXPORT bool operator!=(const Url &a, const Url &b);
+KDUTILS_API bool operator==(const Url &a, const Url &b);
+KDUTILS_API bool operator!=(const Url &a, const Url &b);
 
 } // namespace KDUtils
 


### PR DESCRIPTION
KDUtils was special because it used KDUTILS_EXPORT instead of indirection through KDUTILS_API. Make it same as KDGui and KDFoundation.

Drive-by: Remove unnecessary export marking in url.cpp