### PR TITLE
ci: Add workflow to build against system 3rdparty

### DIFF
--- a/.github/workflows/build-external.yml
+++ b/.github/workflows/build-external.yml
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+# Test on macOS with some dependencies provided externally by Homebrew.
+# Both to validate the CMake setup for using system dependencies and to have early warning
+# about incompatible changes in some fast-moving external libraries.
 name: Build against external 3rdparty
 
 on: [push, pull_request]

--- a/.github/workflows/build-external.yml
+++ b/.github/workflows/build-external.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+#
+# SPDX-License-Identifier: MIT
+
+name: Build against external 3rdparty
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - macos-latest
+        shared:
+          - ON
+          - OFF
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew tap KDAB/tap
+          brew install fmt spdlog KDBindings
+
+      - name: Configure project
+        run: >
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -G Ninja
+          -DKDUTILS_BUILD_TESTS=ON
+          -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+
+      - name: Check if external dependencies were used
+        run: |
+          ! grep -q "KDBindings_DIR-NOTFOUND" ./build/CMakeCache.txt
+          ! grep -q "spdlog_DIR-NOTFOUND" ./build/CMakeCache.txt
+          ! grep -q "fmt_DIR-NOTFOUND" ./build/CMakeCache.txt
+
+      - name: Build Project
+        run: cmake --build ./build
+
+      - name: Run tests
+        run: ctest --test-dir ./build --output-on-failure


### PR DESCRIPTION
This is mostly about `fmt/spdlog` being a fast moving target breaking source-compat as they go along.

Added homebrew only, which has the latest versions, so is enough for good coverage.

Created separate .yml file as the main one is getting complex.