### PR TITLE
remove ubuntu 20.04 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - windows-2022
           - macos-13
           - macos-14


### PR DESCRIPTION
Ubuntu 20.04 is out of support and GitHub Actions is removing the build container for it. If we truly need it, we need to setup a custom container I guess.