### PR TITLE
Make KDUTILS_BUILD_MQTT_SUPPORT a dependent option on Mosquitto being …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,6 @@ else()
     option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 endif()
 
-if(UNIX)
-    option(KDUTILS_BUILD_MQTT_SUPPORT "EXPERIMENTAL: Build KDMqtt" ON)
-else()
-    option(KDUTILS_BUILD_MQTT_SUPPORT "EXPERIMENTAL: Build KDMqtt" OFF)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/ECM/modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/ECM/find-modules")
@@ -53,6 +47,18 @@ include(cmake/dependencies.cmake)
 include(GenerateExportHeader)
 include(GNUInstallDirs)
 include(CTest)
+
+if(UNIX)
+    cmake_dependent_option(
+        KDUTILS_BUILD_MQTT_SUPPORT
+        "EXPERIMENTAL: Build KDMqtt"
+        ON
+        "Mosquitto_FOUND"
+        OFF
+    )
+else()
+    option(KDUTILS_BUILD_MQTT_SUPPORT "EXPERIMENTAL: Build KDMqtt" OFF)
+endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     option(KDUTILS_CODE_COVERAGE "Code Coverage" OFF)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -103,10 +103,4 @@ if(NOT TARGET mio::mio)
 endif()
 
 # mosquitto library
-if(KDUTILS_BUILD_MQTT_SUPPORT)
-    find_package(Mosquitto REQUIRED)
-
-    if(KDUTILS_BUILD_EXAMPLES)
-        file(DOWNLOAD https://test.mosquitto.org/ssl/mosquitto.org.crt ${CMAKE_BINARY_DIR}/mosquitto.org.crt)
-    endif()
-endif()
+find_package(Mosquitto QUIET)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,5 +10,6 @@
 add_subdirectory(gui_window)
 
 if(KDUTILS_BUILD_MQTT_SUPPORT)
+    file(DOWNLOAD https://test.mosquitto.org/ssl/mosquitto.org.crt ${CMAKE_BINARY_DIR}/mosquitto.org.crt)
     add_subdirectory(mqtt_client)
 endif()


### PR DESCRIPTION
So that if you don't have Mosquitto installed we don't block you from building KDUtils which is used by KDGpu, Serenity ...