### PR TITLE
Add experimental Ubuntu Arm64 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-2022
           - macos-13
           - macos-14


### PR DESCRIPTION
For now only the 24.04 one. If they are there, let's check on arm too.