### PR TITLE
Improve MQTT-related CMake files

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,11 +48,12 @@ endif()
 add_subdirectory(auto/utils)
 add_subdirectory(auto/foundation)
 add_subdirectory(auto/gui)
-if(UNIX AND KDUTILS_BUILD_MQTT_SUPPORT)
+if(KDUTILS_BUILD_MQTT_SUPPORT)
     FetchContent_Declare(
         FakeIt
         DOWNLOAD_EXTRACT_TIMESTAMP ON
         URL https://github.com/eranpeer/FakeIt/archive/refs/tags/2.4.1.zip
+        URL_HASH SHA256=384d98a703da5995915933bc61820c9cdc2f96f95db8b2ae86fc5c660f8bb9e8
     )
     FetchContent_MakeAvailable(FakeIt)
 


### PR DESCRIPTION
 - tests only need to rely on MQTT option, not on system. If we get MQTT to work on Windows, it will automatically start including tests
 - Inclue checksum when downloading FakeIt so we don't get Jia Tan'd

Change-Id: I0a26c3441ce9543d843cd2d366537e9d71476dd5