### PR TITLE
Simple touchscreen mouse support for Android

### DIFF
--- a/src/KDGui/platform/android/android_platform_event_loop.cpp
+++ b/src/KDGui/platform/android/android_platform_event_loop.cpp
@@ -63,8 +63,19 @@ int32_t AndroidPlatformEventLoop::androidHandleInputEvent(android_app *app, AInp
             return 0;
         }
         break;
+    case AINPUT_EVENT_TYPE_MOTION: {
+        auto platformIntegration = reinterpret_cast<AndroidPlatformEventLoop *>(AndroidPlatformIntegration::s_androidApp->userData)->androidPlatformIntegration();
+        const auto timestamp = AMotionEvent_getEventTime(event);
+        const auto action = AMotionEvent_getAction(event);
+        // Only track the first touch event
+        const auto xPos = static_cast<int64_t>(AMotionEvent_getX(event, 0));
+        const auto yPos = static_cast<int64_t>(AMotionEvent_getY(event, 0));
+
+        platformIntegration->handleTouchEvent(action, xPos, yPos, timestamp);
+        break;
+    }
+
     // TODO IMPLEMENT ME
-    case AINPUT_EVENT_TYPE_MOTION:
     case AINPUT_EVENT_TYPE_FOCUS:
     case AINPUT_EVENT_TYPE_CAPTURE:
     case AINPUT_EVENT_TYPE_DRAG:

--- a/src/KDGui/platform/android/android_platform_integration.cpp
+++ b/src/KDGui/platform/android/android_platform_integration.cpp
@@ -71,6 +71,30 @@ void AndroidPlatformIntegration::handleKeyEvent(int32_t action, int32_t code, in
     }
 }
 
+void AndroidPlatformIntegration::handleTouchEvent(int32_t action, int64_t xPos, int64_t yPos, int64_t time)
+{
+    const auto mouseButton = LeftButton;
+
+    for (auto *platformWindow : m_windows) {
+
+        switch (action) {
+        case AMOTION_EVENT_ACTION_DOWN:
+            platformWindow->handleMousePress(time, mouseButton, xPos, yPos);
+            break;
+        case AMOTION_EVENT_ACTION_UP:
+            platformWindow->handleMouseRelease(time, mouseButton, xPos, yPos);
+            break;
+        case AMOTION_EVENT_ACTION_MOVE:
+            platformWindow->handleMouseMove(time, mouseButton, xPos, yPos);
+            break;
+        default:
+            __android_log_print(ANDROID_LOG_INFO, "KDGuiAndroid",
+                                "touch event not handled: %d", action);
+            break;
+        }
+    }
+}
+
 void AndroidPlatformIntegration::registerPlatformWindow(AbstractPlatformWindow *window)
 {
     m_windows.insert(window);
@@ -97,7 +121,7 @@ static void handle_cmd(android_app *app, int32_t cmd)
         startMain = false;
         break;
     default:
-        __android_log_print(ANDROID_LOG_INFO, "SerenityNativeApplication",
+        __android_log_print(ANDROID_LOG_INFO, "KDGuiAndroid",
                             "event not handled: %d", cmd);
     }
 }
@@ -117,7 +141,7 @@ void android_main(struct android_app *app)
                 source->process(app, source);
         }
     } while (app->destroyRequested == 0 && !startMain);
-    static const char *appStr = "SerenityNativeApplication";
+    static const char *appStr = "KDGuiAndroid";
     if (startMain && main)
         exit(main(1, &appStr));
     else

--- a/src/KDGui/platform/android/android_platform_integration.h
+++ b/src/KDGui/platform/android/android_platform_integration.h
@@ -35,6 +35,7 @@ public:
     void registerPlatformWindow(AbstractPlatformWindow *window);
     void unregisterPlatformWindow(AbstractPlatformWindow *window);
     void handleKeyEvent(int32_t action, int32_t code, int32_t meta, int64_t time);
+    void handleTouchEvent(int32_t action, int64_t xPos, int64_t yPos, int64_t time);
 
     AbstractClipboard *clipboard() override
     {


### PR DESCRIPTION
Track the status, position and times of the first touch event as equivalent to left mouse button clicks and drags.
Also use a more appropriate tag for logging.

Change-Id: I26fd55ec9f1c255661f4d89d81872d7c73a0c190