### PR TITLE
Set flag DONT_USE_OS_CERTIFICATE_STORE for unencrypted connection in …

### DIFF
--- a/examples/mqtt_client/mqtt_client.cpp
+++ b/examples/mqtt_client/mqtt_client.cpp
@@ -30,7 +30,11 @@ int main()
     CoreApplication app;
 
     MqttManager::instance().init();
-    auto mqttClient = MqttManager::instance().createClient("KDMqttClient", MqttManager::ClientOption::CLEAN_SESSION);
+    MqttManager::ClientOptions options(MqttManager::ClientOption::CLEAN_SESSION);
+    if (!useEncryptedConnection) {
+        options.setFlag(MqttManager::ClientOption::DONT_USE_OS_CERTIFICATE_STORE);
+    }
+    auto mqttClient = MqttManager::instance().createClient("KDMqttClient", options);
 
     auto onMqttConnectionStateChanged = [&](const MqttClient::ConnectionState &connectionState) {
         if (connectionState == MqttClient::ConnectionState::CONNECTED) {


### PR DESCRIPTION
…MQTT client example

Avoids the following connection error in case an **un**encrypted connection is configured in the MQTT client example:
```
[2025-03-04 13:56:14.969] [mqtt] [info] [mqtt.cpp:47] Using libmosquitto v2.0.11
[2025-03-04 13:56:15.293] [mqtt] [error] [mqtt.cpp:96] onReadOpRequested() - error(8): A TLS error occurred.
[2025-03-04 13:56:15.293] [mqtt] [error] [mqtt.cpp:96] onWriteOpRequested() - error(4): The client is not currently connected.
```

We set the mosquitto option to use the OS cert store by default when creating a client instance.
Apparently this leads to a connection error in case an **un**encrypted connection is to be established.

IMO the proposed fix is okay in case we consider encrypted connections to be the default and require to explicitly opt-out of TLS related options in case an **un**encrypted connection is to be established.

Another approach would be to pass the option as parameter to `MqttClient::connect()` which would allow for establishing encrypted and unencrypted connections with the same client without the need for re-instantiation of a `MqttClient` instance since the option can be set on a per-connection basis.