### PR TITLE
Enable operators for KDUtils::Flags<KDMqtt::MqttManager::ClientOptions>

### DIFF
--- a/src/KDMqtt/mqtt.h
+++ b/src/KDMqtt/mqtt.h
@@ -313,3 +313,5 @@ private:
 };
 
 } // namespace KDMqtt
+
+OPERATORS_FOR_FLAGS(KDMqtt::MqttManager::ClientOptions);


### PR DESCRIPTION
Adds missing macro `OPERATORS_FOR_FLAGS` for said enum.