### PR TITLE
Download header only for FakeIt mocking framework

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,13 +49,5 @@ add_subdirectory(auto/utils)
 add_subdirectory(auto/foundation)
 add_subdirectory(auto/gui)
 if(KDUTILS_BUILD_MQTT_SUPPORT)
-    FetchContent_Declare(
-        FakeIt
-        DOWNLOAD_EXTRACT_TIMESTAMP ON
-        URL https://github.com/eranpeer/FakeIt/archive/refs/tags/2.4.1.zip
-        URL_HASH SHA256=384d98a703da5995915933bc61820c9cdc2f96f95db8b2ae86fc5c660f8bb9e8
-    )
-    FetchContent_MakeAvailable(FakeIt)
-
     add_subdirectory(auto/mqtt)
 endif()

--- a/tests/auto/mqtt/CMakeLists.txt
+++ b/tests/auto/mqtt/CMakeLists.txt
@@ -12,6 +12,11 @@ project(KDMqtt-Tests)
 
 include_directories(../KDFoundation/common)
 
+file(DOWNLOAD https://raw.githubusercontent.com/eranpeer/FakeIt/refs/tags/2.4.1/single_header/doctest/fakeit.hpp
+     "${CMAKE_BINARY_DIR}/tests/auto/fakeit.h"
+     EXPECTED_HASH SHA256=09be612875c0dd0c0692256739eb859e66f6e82c1f1082d50eacb670f471f63b
+)
+
 project(
     test-mqtt
     VERSION 0.1
@@ -25,7 +30,7 @@ add_executable(
 
 target_include_directories(
     ${PROJECT_NAME}
-    PRIVATE ${CMAKE_SOURCE_DIR}/tests/auto/foundation/common ${fakeit_SOURCE_DIR}/single_header/doctest
+    PRIVATE ${CMAKE_SOURCE_DIR}/tests/auto/foundation/common ${CMAKE_BINARY_DIR}/tests/auto
 )
 
 target_link_libraries(

--- a/tests/auto/mqtt/tst_mqtt.cpp
+++ b/tests/auto/mqtt/tst_mqtt.cpp
@@ -15,7 +15,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 #include <signal_spy.h>
-#include "fakeit.hpp" // <= include after doctest.h
+#include "fakeit.h" // <= include after doctest.h
 
 using namespace fakeit;
 


### PR DESCRIPTION
Before we have pulled all of the FakeIt source code downloading a zip file via FetchContent.
This had two downsides:
- we only use a single header file from the sources so pulling all of the source code was a bit overkill
- using FetchConents lead to FakeIt files being installed when installing KDUtils library on Linux via `cmake --install . --prefix /path/to/prefix`

Now we download only the single header file we actually use. The new approach also avoids FakeIt files to be included when installing KDUtils library on Linux.

Fixes #60 