### PR TITLE
Add logging to OutputDebugString on Windows

### DIFF
--- a/src/KDUtils/logging.cpp
+++ b/src/KDUtils/logging.cpp
@@ -11,7 +11,10 @@
 #include "logging.h"
 #if defined(ANDROID)
 #include <spdlog/sinks/android_sink.h>
+#elif defined(_WIN32)
+#include <spdlog/sinks/msvc_sink.h>
 #endif
+
 namespace KDUtils {
 
 Logger::LoggerFactoryFunction Logger::ms_loggerFactory = {};
@@ -29,6 +32,11 @@ std::shared_ptr<spdlog::logger> Logger::logger(const std::string &name, spdlog::
         if (!logger) {
 #if defined(ANDROID)
             logger = spdlog::android_logger_mt(name, name);
+#elif defined(_WIN32)
+            // Create both msvc_sink and stdout_color_sink
+            auto msvc_sink = std::make_shared<spdlog::sinks::msvc_sink_mt>();
+            auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+            logger = std::make_shared<spdlog::logger>(name, spdlog::sinks_init_list{ msvc_sink, console_sink });
 #else
             logger = spdlog::stdout_color_mt(name);
 #endif


### PR DESCRIPTION
In a non-console app on Windows, no logging is visible, so on that platform add the sink for output to the Visual Studio debug output pane.

Also remove unnecessary #ifdef, since the included headers have those.