### PR TITLE
Use doctest revision compatible with CMake 4.0

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ else()
     fetchcontent_declare(
         doctest
         GIT_REPOSITORY https://github.com/doctest/doctest.git
-        GIT_TAG ae7a13539fb71f270b87eb2e874fbac80bc8dda2 # v2.4.11
+        GIT_TAG 3a01ec37828affe4c9650004edb5b304fb9d5b75 # dev branch commit with CMake compatibility fix
     )
     fetchcontent_makeavailable(doctest)
 


### PR DESCRIPTION
It's not available in any released version so we have to get the revision from dev. The changes since 2.4.11 up to this rev were minimal however so we should be safe.