### PR TITLE
Don't leak mosquitto headers

### DIFF
--- a/src/KDMqtt/mqtt.cpp
+++ b/src/KDMqtt/mqtt.cpp
@@ -9,6 +9,7 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 #include "mqtt.h"
+#include "mosquitto_wrapper.h"
 #include <memory>
 #include <spdlog/spdlog.h>
 

--- a/src/KDMqtt/mqtt.h
+++ b/src/KDMqtt/mqtt.h
@@ -13,7 +13,6 @@
 #include <KDFoundation/file_descriptor_notifier.h>
 #include <KDFoundation/timer.h>
 #include <KDMqtt/kdmqtt_global.h>
-#include <KDMqtt/mosquitto_wrapper.h>
 #include <KDUtils/bytearray.h>
 #include <KDUtils/file.h>
 #include <KDUtils/flags.h>
@@ -28,12 +27,16 @@
 using namespace KDFoundation;
 using namespace KDUtils;
 
+struct mosquitto_message;
+
 namespace KDMqtt {
 
 constexpr int c_defaultPort = 1883;
 constexpr std::chrono::duration c_defaultKeepAlive = std::chrono::minutes(1);
 
 class IMqttClient;
+class MosquittoLib;
+class MosquittoClient;
 
 /*
  * Class: IMqttManager

--- a/tests/auto/mqtt/CMakeLists.txt
+++ b/tests/auto/mqtt/CMakeLists.txt
@@ -30,7 +30,8 @@ add_executable(
 
 target_include_directories(
     ${PROJECT_NAME}
-    PRIVATE ${CMAKE_SOURCE_DIR}/tests/auto/foundation/common ${CMAKE_BINARY_DIR}/tests/auto
+    PRIVATE ${CMAKE_SOURCE_DIR}/src/KDMqtt ${CMAKE_SOURCE_DIR}/tests/auto/foundation/common
+            ${CMAKE_BINARY_DIR}/tests/auto
 )
 
 target_link_libraries(

--- a/tests/auto/mqtt/tst_mqtt.cpp
+++ b/tests/auto/mqtt/tst_mqtt.cpp
@@ -11,6 +11,7 @@
 #include <KDFoundation/core_application.h>
 #include <KDMqtt/mqtt.h>
 #include <memory>
+#include "mosquitto_wrapper.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>


### PR DESCRIPTION
We only use mosquitto types via pointers so we don't need full mosquitto headers to be included in our exported headers. This will make the life of users easier. We'll have only link time dependency.