### PR TITLE
destruction_helpers.h: remove using namespace KDBindings

### DIFF
--- a/src/KDFoundation/destruction_helpers.h
+++ b/src/KDFoundation/destruction_helpers.h
@@ -16,8 +16,6 @@
 
 #include <map>
 
-using namespace KDBindings;
-
 // TODO: Maybe belongs to ecs?
 
 namespace KDFoundation {
@@ -26,22 +24,22 @@ template<typename ContainerType, typename DependencyType>
 class DestructionHelperManager
 {
 public:
-    ConnectionHandle contToDepConnection(std::pair<ContainerType *, DependencyType *> contDepPair)
+    KDBindings::ConnectionHandle contToDepConnection(std::pair<ContainerType *, DependencyType *> contDepPair)
     {
         return m_contToDepMap[contDepPair];
     }
 
-    ConnectionHandle depToContConnection(std::pair<DependencyType *, ContainerType *> depContPair)
+    KDBindings::ConnectionHandle depToContConnection(std::pair<DependencyType *, ContainerType *> depContPair)
     {
         return m_depToContMap[depContPair];
     }
 
-    void addContToDepConnection(std::pair<ContainerType *, DependencyType *> contDepPair, ConnectionHandle handle)
+    void addContToDepConnection(std::pair<ContainerType *, DependencyType *> contDepPair, KDBindings::ConnectionHandle handle)
     {
         m_contToDepMap[contDepPair] = handle;
     }
 
-    void addDepToContConnection(std::pair<DependencyType *, ContainerType *> depContPair, ConnectionHandle handle)
+    void addDepToContConnection(std::pair<DependencyType *, ContainerType *> depContPair, KDBindings::ConnectionHandle handle)
     {
         m_depToContMap[depContPair] = handle;
     }
@@ -62,7 +60,7 @@ public:
         }
     }
 
-    void clearDepToContConnctions()
+    void clearDepToContConnections()
     {
         for (const auto &depConn : m_depToContMap) {
             depConn.first.first->destroyed.disconnect(depConn.second);
@@ -71,12 +69,14 @@ public:
     }
 
 private:
-    std::map<std::pair<ContainerType *, DependencyType *>, ConnectionHandle> m_contToDepMap;
-    std::map<std::pair<DependencyType *, ContainerType *>, ConnectionHandle> m_depToContMap;
+    std::map<std::pair<ContainerType *, DependencyType *>, KDBindings::ConnectionHandle> m_contToDepMap;
+    std::map<std::pair<DependencyType *, ContainerType *>, KDBindings::ConnectionHandle> m_depToContMap;
 };
 
+// Watch object held by property of type KDBinding::Property<DependencyType *> and resets property value if node is destroyed
+// Optional property owner can be passed in
 template<typename DependencyType, typename ContainerType>
-void registerDestructionHelper(Property<DependencyType *> *property, ConnectionHandle *connectionHandle, ContainerType *owner)
+void registerDestructionHelper(KDBindings::Property<DependencyType *> *property, KDBindings::ConnectionHandle *connectionHandle, ContainerType *owner)
 {
     std::ignore = property->valueAboutToChange().connect([=](DependencyType *oldVal, DependencyType * /* newVal */) {
         if (!oldVal) {
@@ -101,6 +101,7 @@ void registerDestructionHelper(Property<DependencyType *> *property, ConnectionH
     }
 }
 
+// Triggers dependencyCleanupFunctor when DependencyType instance referenced by Container is destroyed
 template<typename ContainerType, typename DependencyType, typename OnDepenencyDestructionFunctorType>
 void registerDestructionHelper(ContainerType *container, DependencyType *dependency, DestructionHelperManager<ContainerType, DependencyType> *manager, OnDepenencyDestructionFunctorType dependencyCleanupFunctor)
 {
@@ -115,7 +116,7 @@ void registerDestructionHelper(ContainerType *container, DependencyType *depende
 
     if (container) {
         auto contToDep = container->destroyed.connect([=] {
-            manager->clearDepToContConnctions();
+            manager->clearDepToContConnections();
             manager->delContToDepConnection({ container, dependency });
         });
 

--- a/tests/auto/foundation/CMakeLists.txt
+++ b/tests/auto/foundation/CMakeLists.txt
@@ -40,6 +40,7 @@ add_subdirectory(core_application)
 add_subdirectory(event)
 add_subdirectory(event_queue)
 add_subdirectory(object)
+add_subdirectory(destruction_helper)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_subdirectory(linux_platform_event_loop)

--- a/tests/auto/foundation/destruction_helper/CMakeLists.txt
+++ b/tests/auto/foundation/destruction_helper/CMakeLists.txt
@@ -1,0 +1,17 @@
+# This file is part of KDUtils.
+#
+# SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# Author: Paul Lemire <paul.lemire@kdab.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# Contact KDAB at <info@kdab.com> for commercial licensing options.
+#
+
+project(
+    test-core-destruction-helper
+    VERSION 0.1
+    LANGUAGES CXX
+)
+
+add_core_test(${PROJECT_NAME} tst_destruction_helper.cpp)

--- a/tests/auto/foundation/destruction_helper/tst_destruction_helper.cpp
+++ b/tests/auto/foundation/destruction_helper/tst_destruction_helper.cpp
@@ -1,0 +1,131 @@
+/*
+  This file is part of KDUtils.
+
+  SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  Author: Paul Lemire <paul.lemire@kdab.com>
+
+  SPDX-License-Identifier: MIT
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include <KDFoundation/destruction_helpers.h>
+#include <KDFoundation/object.h>
+#include <signal_spy.h>
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest.h>
+
+using namespace KDFoundation;
+
+class Node : public Object
+{
+public:
+    Node()
+    {
+    }
+
+    // NOLINTBEGIN(bugprone-exception-escape)
+    ~Node()
+    {
+        destroyed.emit(this);
+    }
+    // NOLINTEND(bugprone-exception-escape)
+
+    KDBindings::Signal<Node *> destroyed;
+    KDBindings::Property<Node *> prop{ nullptr };
+};
+
+TEST_SUITE("DesctructionHelper")
+{
+    TEST_CASE("registerDestructionHelper Container & Dependency")
+    {
+        // GIVEN
+        KDFoundation::DestructionHelperManager<Node, Node> destructionManager;
+        Node container;
+        int dependencyDestroyedNotificationCount = 0;
+
+        // WHEN
+        {
+            Node dependency;
+            registerDestructionHelper(&container, &dependency, &destructionManager, [&]() {
+                ++dependencyDestroyedNotificationCount;
+            });
+        }
+
+        // THEN
+        CHECK(dependencyDestroyedNotificationCount == 1);
+    }
+
+    TEST_CASE("unregisterDestructionHelper Container & Dependency")
+    {
+        // GIVEN
+        KDFoundation::DestructionHelperManager<Node, Node> destructionManager;
+        Node container;
+        int dependencyDestroyedNotificationCount = 0;
+
+        // WHEN
+        {
+            Node dependency;
+            registerDestructionHelper(&container, &dependency, &destructionManager, [&]() {
+                ++dependencyDestroyedNotificationCount;
+            });
+            unregisterDestructionHelper(&container, &dependency, &destructionManager);
+        }
+
+        // THEN
+        CHECK(dependencyDestroyedNotificationCount == 0);
+    }
+
+    TEST_CASE("registerDestructionHelper Property")
+    {
+        // GIVEN
+        KDBindings::Property<Node *> dependencyProp{ nullptr };
+        KDBindings::ConnectionHandle connection;
+
+        // WHEN
+        {
+            Node dependency;
+            registerDestructionHelper(&dependencyProp, &connection, static_cast<Node *>(nullptr));
+            dependencyProp = &dependency;
+
+            // THEN
+            CHECK(dependencyProp() == &dependency);
+            CHECK(connection.isActive());
+        }
+
+        // cppcheck-suppress invalidLifetime
+        CHECK(dependencyProp() == nullptr);
+        CHECK(!connection.isActive());
+    }
+
+    TEST_CASE("registerDestructionHelper Property & Owner")
+    {
+        // GIVEN
+        KDBindings::ConnectionHandle connection;
+
+        // WHEN
+        {
+            Node container;
+
+            {
+                Node dependency;
+
+                // WHEN
+                registerDestructionHelper(&container.prop, &connection, &container);
+                container.prop = &dependency;
+
+                // THEN -> Dependency is watched
+                CHECK(container.prop() == &dependency);
+                CHECK(connection.isActive());
+            }
+
+            // THEN -> Property was reset since watched node was destroyed
+            CHECK(container.prop() == nullptr);
+            CHECK(!connection.isActive());
+        }
+
+        // THEN -> Connectio resets since owner destroyed
+        CHECK(!connection.isActive());
+    }
+}


### PR DESCRIPTION
Because headers should never have a using namespace declaration.

Also fix typos, add unit tests and minimal documentation.

Change-Id: Ic524c53417da7273c15c1c9eaa5f8ef8758340af