### PR TITLE
Object: make it possible to create children that take in refs as ctor parameters

### DIFF
--- a/src/KDFoundation/object.h
+++ b/src/KDFoundation/object.h
@@ -62,7 +62,7 @@ public:
     }
 
     template<typename T, typename... Ts>
-    T *createChild(Ts... args)
+    T *createChild(Ts &&...args)
     {
         auto child = std::make_unique<T>(std::forward<Ts>(args)...);
         return static_cast<T *>(this->addChild(std::move(child)));


### PR DESCRIPTION
Otherwise we could only pass params by value