### PR TITLE
Add a public EventLoop class

### DIFF
--- a/src/KDFoundation/CMakeLists.txt
+++ b/src/KDFoundation/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Threads)
 
 set(SOURCES
     core_application.cpp
+    event_loop.cpp
     event_receiver.cpp
     event.cpp
     file_descriptor_notifier.cpp
@@ -25,6 +26,7 @@ set(HEADERS
     constexpr_sort.h
     core_application.h
     destruction_helpers.h
+    event_loop.h
     event_queue.h
     event_receiver.h
     event.h

--- a/src/KDFoundation/core_application.cpp
+++ b/src/KDFoundation/core_application.cpp
@@ -27,10 +27,27 @@ using namespace KDFoundation;
 
 CoreApplication *CoreApplication::ms_application = nullptr;
 
+namespace {
+std::unique_ptr<AbstractPlatformIntegration> createPlatformIntegration()
+{
+    // Create a platform integration
+    #if defined(PLATFORM_LINUX)
+    return std::make_unique<LinuxPlatformIntegration>();
+    #elif defined(PLATFORM_WIN32)
+    return std::make_unique<Win32PlatformIntegration>();
+    #elif defined(PLATFORM_MACOS)
+    return std::make_unique<MacOSPlatformIntegration>();
+    #else
+    static_assert(false, "No valid platform integration could be found.");
+    #endif
+}
+} // namespace
+
 CoreApplication::CoreApplication(std::unique_ptr<AbstractPlatformIntegration> &&platformIntegration)
     : m_defaultLogger{ KDUtils::Logger::logger("default_log", spdlog::level::info) }
-    , m_platformIntegration{ std::move(platformIntegration) }
+    , m_platformIntegration{ platformIntegration ? std::move(platformIntegration) : createPlatformIntegration() }
     , m_logger{ KDUtils::Logger::logger("core_application") }
+    , m_eventLoop{ m_platformIntegration->createPlatformEventLoop() }
 {
     assert(ms_application == nullptr);
     ms_application = this;
@@ -41,25 +58,7 @@ CoreApplication::CoreApplication(std::unique_ptr<AbstractPlatformIntegration> &&
     if (const char *display = std::getenv("DISPLAY")) // NOLINT(concurrency-mt-unsafe)
         SPDLOG_LOGGER_INFO(m_logger, "DISPLAY={}", display);
 
-    // Create a default postman object
-    m_postman = std::make_unique<Postman>();
-
-    // Create a platform integration
-    if (!m_platformIntegration) {
-#if defined(PLATFORM_LINUX)
-        m_platformIntegration = std::make_unique<LinuxPlatformIntegration>();
-#elif defined(PLATFORM_WIN32)
-        m_platformIntegration = std::make_unique<Win32PlatformIntegration>();
-#elif defined(PLATFORM_MACOS)
-        m_platformIntegration = std::make_unique<MacOSPlatformIntegration>();
-#endif
-    }
-
-    // Ask the platform integration to create us a suitable event loop
-    assert(m_platformIntegration);
-    m_platformEventLoop = m_platformIntegration->createPlatformEventLoop();
     m_platformIntegration->init();
-    m_platformEventLoop->setPostman(m_postman.get());
 }
 
 CoreApplication::~CoreApplication()
@@ -69,64 +68,38 @@ CoreApplication::~CoreApplication()
     processEvents(0);
 
     // Destroy the event loop and platform integration before removing the app instance
-    m_platformEventLoop = std::unique_ptr<AbstractPlatformEventLoop>();
-    m_platformIntegration = std::unique_ptr<AbstractPlatformIntegration>();
+    m_platformIntegration.reset();
     ms_application = nullptr;
 }
 
 std::shared_ptr<KDBindings::ConnectionEvaluator> CoreApplication::connectionEvaluator()
 {
-    return eventLoop()->connectionEvaluator();
+    return m_eventLoop.connectionEvaluator();
 }
 
 void CoreApplication::postEvent(EventReceiver *target, std::unique_ptr<Event> &&event)
 {
-    assert(target != nullptr);
-    assert(event->type() != Event::Type::Invalid);
-    m_eventQueue.push(target, std::forward<std::unique_ptr<Event>>(event));
-    m_platformEventLoop->wakeUp();
+    m_eventLoop.postEvent(target, std::forward<std::unique_ptr<Event>>(event));
 }
 
 void CoreApplication::sendEvent(EventReceiver *target, Event *event)
 {
-    SPDLOG_LOGGER_TRACE(m_logger, "{}()", __FUNCTION__);
-    m_postman->deliverEvent(target, event);
+    m_eventLoop.sendEvent(target, event);
 }
 
 void CoreApplication::processEvents(int timeout)
 {
-    // Deliver any events that have already been posted
-    for (size_t eventIndex = 0, eventCount = m_eventQueue.size(); eventIndex < eventCount; ++eventIndex) {
-        auto postedEvent = m_eventQueue.tryPop();
-        if (!postedEvent)
-            break;
-        const auto target = postedEvent->target();
-        const auto ev = postedEvent->wrappedEvent();
-
-        m_postman->deliverEvent(target, ev);
-    }
-
-    // Poll/wait for new events
-    if (!m_platformEventLoop)
-        return;
-    m_platformEventLoop->waitForEvents(timeout);
+    m_eventLoop.processEvents(timeout);
 }
 
 int CoreApplication::exec()
 {
-    if (!m_platformEventLoop)
-        return 1;
-
-    while (!m_quitRequested)
-        processEvents(-1);
-    m_quitRequested = false;
-
-    return 0;
+    return m_eventLoop.exec();
 }
 
 void CoreApplication::quit()
 {
-    postEvent(this, std::make_unique<QuitEvent>());
+    m_eventLoop.quit();
 }
 
 AbstractPlatformIntegration *CoreApplication::platformIntegration()
@@ -141,8 +114,7 @@ void CoreApplication::event(EventReceiver *target, Event *event)
         // because processEvents() goes back into waitForEvents() after processing the
         // queued events. Without the wakeUp() call it would wait until some other event
         // woke it up again. Let's kick it ourselves.
-        m_quitRequested = true;
-        m_platformEventLoop->wakeUp();
+        m_eventLoop.quit();
         event->setAccepted(true);
     }
 

--- a/src/KDFoundation/core_application.h
+++ b/src/KDFoundation/core_application.h
@@ -13,6 +13,7 @@
 
 #include <KDFoundation/kdfoundation_global.h>
 #include <KDFoundation/object.h>
+#include <KDFoundation/event_loop.h>
 #include <KDFoundation/event_queue.h>
 #include <KDFoundation/platform/abstract_platform_integration.h>
 
@@ -42,14 +43,17 @@ public:
 
     static inline CoreApplication *instance() { return ms_application; }
 
-    const AbstractPlatformEventLoop *eventLoop() const { return m_platformEventLoop.get(); }
-    AbstractPlatformEventLoop *eventLoop() { return m_platformEventLoop.get(); }
+    const EventLoop *eventLoop() const { return &m_eventLoop; }
+    EventLoop *eventLoop() { return &m_eventLoop; }
 
-    Postman *postman() { return m_postman.get(); }
+    const AbstractPlatformEventLoop *platformEventLoop() const { return m_eventLoop.platformEventLoop(); }
+    AbstractPlatformEventLoop *platformEventLoop() { return m_eventLoop.platformEventLoop(); }
+
+    Postman *postman() { return m_eventLoop.postman(); }
 
     void postEvent(EventReceiver *target, std::unique_ptr<Event> &&event);
-    void removeAllEventsTargeting(EventReceiver &evReceiver) { m_eventQueue.removeAllEventsTargeting(evReceiver); }
-    EventQueue::size_type eventQueueSize() const { return m_eventQueue.size(); }
+    void removeAllEventsTargeting(EventReceiver &evReceiver) { m_eventLoop.removeAllEventsTargeting(evReceiver); }
+    EventQueue::size_type eventQueueSize() const { return m_eventLoop.eventQueueSize(); }
 
     void sendEvent(EventReceiver *target, Event *event);
 
@@ -68,14 +72,10 @@ public:
     std::shared_ptr<spdlog::logger> m_defaultLogger;
 
 private:
-    void init();
     void event(EventReceiver *target, Event *event) override;
 
-    EventQueue m_eventQueue;
-    bool m_quitRequested{ false };
     std::unique_ptr<AbstractPlatformIntegration> m_platformIntegration;
-    std::unique_ptr<AbstractPlatformEventLoop> m_platformEventLoop;
-    std::unique_ptr<Postman> m_postman;
+    EventLoop m_eventLoop;
     std::shared_ptr<spdlog::logger> m_logger;
 };
 

--- a/src/KDFoundation/event_loop.cpp
+++ b/src/KDFoundation/event_loop.cpp
@@ -1,0 +1,123 @@
+/*
+ *  This file is part of KDUtils.
+ *
+ *  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+ *  Author: Paul Lemire <paul.lemire@kdab.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ *  Contact KDAB at <info@kdab.com> for commercial licensing options.
+ */
+
+#include <KDFoundation/event_loop.h>
+#include <KDFoundation/core_application.h>
+#include <KDFoundation/platform/abstract_platform_event_loop.h>
+#include "postman.h"
+
+#if defined(PLATFORM_LINUX)
+#include <KDFoundation/platform/linux/linux_platform_integration.h>
+#elif defined(PLATFORM_WIN32)
+#include <KDFoundation/platform/win32/win32_platform_integration.h>
+#elif defined(PLATFORM_MACOS)
+#include <KDFoundation/platform/macos/macos_platform_integration.h>
+#endif
+
+#include <cassert>
+
+using namespace KDFoundation;
+
+thread_local EventLoop *EventLoop::ms_instance = nullptr;
+
+EventLoop *EventLoop::instance()
+{
+    return ms_instance;
+}
+
+namespace {
+std::unique_ptr<AbstractPlatformEventLoop> createPlatformEventLoop()
+{
+    // Ask the platform integration to create us a suitable event loop
+    CoreApplication *app = CoreApplication::instance();
+    assert(app && "Cannot use EventLoop without a CoreApplication.");
+    AbstractPlatformIntegration *platformIntegration = app->platformIntegration();
+    assert(platformIntegration);
+    return platformIntegration->createPlatformEventLoop();
+}
+}
+
+EventLoop::EventLoop(std::unique_ptr<AbstractPlatformEventLoop> platformEventLoop)
+    : m_platformEventLoop(platformEventLoop ? std::move(platformEventLoop) : createPlatformEventLoop())
+{
+    // Create a default postman object
+    m_postman = std::make_unique<Postman>();
+    m_platformEventLoop->setPostman(m_postman.get());
+
+    assert(ms_instance == nullptr && "Cannot have more than one event loop per thread. Nested event loops are not supported.");
+    ms_instance = this;
+}
+
+EventLoop::~EventLoop()
+{
+    // Destroy the platform event loop before removing the event loop instance
+    m_platformEventLoop.reset();
+    ms_instance = nullptr;
+}
+
+std::shared_ptr<KDBindings::ConnectionEvaluator> EventLoop::connectionEvaluator()
+{
+    return m_platformEventLoop->connectionEvaluator();
+}
+
+void EventLoop::postEvent(EventReceiver *target, std::unique_ptr<Event> &&event)
+{
+    assert(target != nullptr);
+    assert(event->type() != Event::Type::Invalid);
+    m_eventQueue.push(target, std::forward<std::unique_ptr<Event>>(event));
+    m_platformEventLoop->wakeUp();
+}
+
+void EventLoop::sendEvent(EventReceiver *target, Event *event)
+{
+    m_postman->deliverEvent(target, event);
+}
+
+void EventLoop::processEvents(int timeout)
+{
+    // Deliver any events that have already been posted
+    for (size_t eventIndex = 0, eventCount = m_eventQueue.size(); eventIndex < eventCount; ++eventIndex) {
+        auto postedEvent = m_eventQueue.tryPop();
+        if (!postedEvent)
+            break;
+        const auto target = postedEvent->target();
+        const auto ev = postedEvent->wrappedEvent();
+
+        m_postman->deliverEvent(target, ev);
+    }
+
+    // Poll/wait for new events
+    if (!m_platformEventLoop)
+        return;
+    m_platformEventLoop->waitForEvents(timeout);
+}
+
+int EventLoop::exec()
+{
+    if (!m_platformEventLoop)
+        return 1;
+
+    while (!m_quitRequested)
+        processEvents(-1);
+    m_quitRequested = false;
+
+    return 0;
+}
+
+void EventLoop::quit()
+{
+    // After setting the quit flag to true, we must wake up the event loop once more,
+    // because processEvents() goes back into waitForEvents() after processing the
+    // queued events. Without the wakeUp() call it would wait until some other event
+    // woke it up again. Let's kick it ourselves.
+    m_quitRequested = true;
+    m_platformEventLoop->wakeUp();
+}

--- a/src/KDFoundation/event_loop.h
+++ b/src/KDFoundation/event_loop.h
@@ -1,0 +1,68 @@
+/*
+ *  This file is part of KDUtils.
+ *
+ *  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+ *  Author: Paul Lemire <paul.lemire@kdab.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ *  Contact KDAB at <info@kdab.com> for commercial licensing options.
+ */
+
+#pragma once
+
+#include <KDFoundation/kdfoundation_global.h>
+#include <KDFoundation/object.h>
+#include <KDFoundation/event_queue.h>
+#include <KDFoundation/platform/abstract_platform_integration.h>
+
+#include <KDUtils/logging.h>
+#include <KDUtils/dir.h>
+
+#include <kdbindings/property.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace KDFoundation {
+
+    class AbstractPlatformEventLoop;
+    class Postman;
+
+    class KDFOUNDATION_API EventLoop
+    {
+    public:
+        EventLoop(std::unique_ptr<AbstractPlatformEventLoop> platformEventLoop = nullptr);
+        ~EventLoop();
+
+        static EventLoop *instance();
+
+        const AbstractPlatformEventLoop *platformEventLoop() const { return m_platformEventLoop.get(); }
+        AbstractPlatformEventLoop *platformEventLoop() { return m_platformEventLoop.get(); }
+
+        Postman *postman() { return m_postman.get(); }
+
+        void postEvent(EventReceiver *target, std::unique_ptr<Event> &&event);
+        void removeAllEventsTargeting(EventReceiver &evReceiver) { m_eventQueue.removeAllEventsTargeting(evReceiver); }
+        EventQueue::size_type eventQueueSize() const { return m_eventQueue.size(); }
+
+        void sendEvent(EventReceiver *target, Event *event);
+
+        void processEvents(int timeout = 0);
+
+        int exec();
+        void quit();
+
+        std::shared_ptr<KDBindings::ConnectionEvaluator> connectionEvaluator();
+
+    private:
+        thread_local static EventLoop *ms_instance;
+        EventQueue m_eventQueue;
+        bool m_quitRequested = false;
+        std::unique_ptr<AbstractPlatformEventLoop> m_platformEventLoop;
+        std::unique_ptr<Postman> m_postman;
+    };
+
+} // namespace KDFoundation

--- a/src/KDFoundation/event_receiver.cpp
+++ b/src/KDFoundation/event_receiver.cpp
@@ -16,6 +16,11 @@ using namespace KDFoundation;
 
 EventReceiver::~EventReceiver() noexcept
 {
-    if (CoreApplication::instance() != nullptr)
+    // Clear this thread's and the main event loop from events targeting this receiver
+    // FIXME Events posted to other threads' event loops are not cleared
+    if (EventLoop::instance() != nullptr)
+        EventLoop::instance()->removeAllEventsTargeting(*this);
+
+    if (CoreApplication::instance() != nullptr && CoreApplication::instance()->eventLoop() != EventLoop::instance())
         CoreApplication::instance()->removeAllEventsTargeting(*this);
 }

--- a/src/KDFoundation/object.cpp
+++ b/src/KDFoundation/object.cpp
@@ -26,8 +26,8 @@ Object::Object()
 
 void Object::deleteLater()
 {
-    if (CoreApplication::instance() == nullptr) {
-        SPDLOG_ERROR("No CoreApplication object to schedule deferred deletion of object with.");
+    if (EventLoop::instance() == nullptr) {
+        SPDLOG_ERROR("No EventLoop to schedule deferred deletion of object with.");
         return;
     }
 
@@ -37,7 +37,7 @@ void Object::deleteLater()
     }
 
     auto ev = std::make_unique<DeferredDeleteEvent>();
-    CoreApplication::instance()->postEvent(this, std::move(ev));
+    EventLoop::instance()->postEvent(this, std::move(ev));
 }
 
 Object::~Object()

--- a/src/KDFoundation/platform/abstract_platform_integration.h
+++ b/src/KDFoundation/platform/abstract_platform_integration.h
@@ -34,6 +34,11 @@ class KDFOUNDATION_API AbstractPlatformIntegration
 public:
     virtual ~AbstractPlatformIntegration() { }
 
+    /**
+     * Finalize initialization of the platform integration.
+     *
+     * @warning This is called before CoreApplication and its subclasses are fully initialized.
+     */
     virtual void init() { }
     std::unique_ptr<AbstractPlatformEventLoop> createPlatformEventLoop()
     {
@@ -44,6 +49,11 @@ public:
     virtual KDUtils::Dir standardDir(const CoreApplication &app, StandardDir type) const = 0;
 
 private:
+    /**
+     * Create and return a platform event loop.
+     *
+     * @warning Might be called before @e AbstractPlatformIntegration::init.
+     */
     virtual AbstractPlatformEventLoop *createPlatformEventLoopImpl() = 0;
 };
 

--- a/src/KDFoundation/platform/macos/macos_platform_timer.mm
+++ b/src/KDFoundation/platform/macos/macos_platform_timer.mm
@@ -28,7 +28,7 @@ using namespace KDFoundation;
 
 inline MacOSPlatformEventLoop *eventLoop()
 {
-    return static_cast<MacOSPlatformEventLoop *>(CoreApplication::instance()->eventLoop());
+    return static_cast<MacOSPlatformEventLoop *>(EventLoop::instance()->platformEventLoop());
 }
 
 MacOSPlatformTimer::MacOSPlatformTimer(Timer *timer)

--- a/src/KDFoundation/platform/win32/win32_platform_timer.cpp
+++ b/src/KDFoundation/platform/win32/win32_platform_timer.cpp
@@ -21,7 +21,7 @@ using namespace KDFoundation;
 
 inline Win32PlatformEventLoop *eventLoop()
 {
-    return static_cast<Win32PlatformEventLoop *>(CoreApplication::instance()->eventLoop());
+    return static_cast<Win32PlatformEventLoop *>(EventLoop::instance()->platformEventLoop());
 }
 
 Win32PlatformTimer::Win32PlatformTimer(Timer *timer)

--- a/src/KDFoundation/timer.cpp
+++ b/src/KDFoundation/timer.cpp
@@ -12,13 +12,22 @@
 #include "timer.h"
 
 #include "core_application.h"
-#include "platform/abstract_platform_integration.h"
+#include "event_loop.h"
 #include "platform/abstract_platform_timer.h"
 
 using namespace KDFoundation;
 
+namespace {
+std::unique_ptr<AbstractPlatformTimer> createPlatformTimer(Timer *instance)
+{
+  auto eventLoop = EventLoop::instance();
+  assert(eventLoop && "Current thread must have an event loop. Create an instance of KDFoundation::EventLoop on the local thread to use a timer.");
+  return eventLoop->platformEventLoop()->createPlatformTimer(instance);
+}
+}
+
 Timer::Timer()
-    : m_platformTimer(CoreApplication::instance()->eventLoop()->createPlatformTimer(this))
+    : m_platformTimer(createPlatformTimer(this))
 {
 }
 

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_event_loop.cpp
@@ -21,12 +21,12 @@ LinuxWaylandPlatformEventLoop::LinuxWaylandPlatformEventLoop(LinuxWaylandPlatfor
     : m_logger{ platformIntegration->logger() }
     , m_platformIntegration{ platformIntegration }
 {
+    const int fd = wl_display_get_fd(m_platformIntegration->display());
+    registerFileDescriptor(fd, FileDescriptorNotifier::NotificationType::Read);
 }
 
 void LinuxWaylandPlatformEventLoop::init()
 {
-    const int fd = wl_display_get_fd(m_platformIntegration->display());
-    registerFileDescriptor(fd, FileDescriptorNotifier::NotificationType::Read);
 }
 
 LinuxWaylandPlatformEventLoop::~LinuxWaylandPlatformEventLoop()

--- a/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
+++ b/src/KDGui/platform/linux/wayland/linux_wayland_platform_integration.cpp
@@ -33,24 +33,6 @@ LinuxWaylandPlatformIntegration::LinuxWaylandPlatformIntegration()
     : m_logger{ KDUtils::Logger::logger("wayland", spdlog::level::info) }
     , m_clipboard{ new LinuxWaylandClipboard{ this } }
 {
-}
-
-LinuxWaylandPlatformIntegration::~LinuxWaylandPlatformIntegration()
-{
-    m_outputs.clear();
-    m_inputs.clear();
-
-    xdg_wm_base_destroy(m_xdgShell.object);
-    wl_compositor_destroy(m_compositor.object);
-    wl_shm_destroy(m_shm.object);
-
-    wl_registry_destroy(m_registry);
-    wl_display_disconnect(m_display);
-    SPDLOG_LOGGER_DEBUG(m_logger, "Destroyed wl_display");
-}
-
-void LinuxWaylandPlatformIntegration::init()
-{
     SPDLOG_LOGGER_INFO(m_logger, "Wayland display is: {}", std::getenv("WAYLAND_DISPLAY")); // NOLINT(concurrency-mt-unsafe)
 
     m_display = wl_display_connect(nullptr);
@@ -79,6 +61,24 @@ void LinuxWaylandPlatformIntegration::init()
         wrapWlCallback<&LinuxWaylandPlatformIntegration::globalRemove>
     };
     wl_registry_add_listener(m_registry, &listener, this);
+}
+
+LinuxWaylandPlatformIntegration::~LinuxWaylandPlatformIntegration()
+{
+    m_outputs.clear();
+    m_inputs.clear();
+
+    xdg_wm_base_destroy(m_xdgShell.object);
+    wl_compositor_destroy(m_compositor.object);
+    wl_shm_destroy(m_shm.object);
+
+    wl_registry_destroy(m_registry);
+    wl_display_disconnect(m_display);
+    SPDLOG_LOGGER_DEBUG(m_logger, "Destroyed wl_display");
+}
+
+void LinuxWaylandPlatformIntegration::init()
+{
     wl_display_roundtrip_queue(m_display, m_queue);
 
     if (!m_compositor.object) {
@@ -95,7 +95,6 @@ void LinuxWaylandPlatformIntegration::init()
     }
 
     m_cursorTheme = wl_cursor_theme_load(nullptr, 24, m_shm.object);
-    static_cast<LinuxWaylandPlatformEventLoop *>(KDFoundation::CoreApplication::instance()->eventLoop())->init();
 }
 
 bool LinuxWaylandPlatformIntegration::checkAvailable()

--- a/tests/auto/foundation/common/event_mockups.h
+++ b/tests/auto/foundation/common/event_mockups.h
@@ -1,0 +1,105 @@
+/*
+ * This file is part of KDUtils.
+ *
+ * SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+ * Author: Paul Lemire <paul.lemire@kdab.com>
+ * Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Contact KDAB at <info@kdab.com> for commercial licensing options.
+ */
+
+#pragma once
+
+#include <KDFoundation/event.h>
+#include <KDFoundation/event_loop.h>
+#include <KDFoundation/event_receiver.h>
+#include <KDFoundation/object.h>
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest.h>
+
+class PayloadEvent : public KDFoundation::Event
+{
+public:
+    PayloadEvent(int x, int y)
+    : Event(static_cast<KDFoundation::Event::Type>(static_cast<uint16_t>(KDFoundation::Event::Type::UserType) + 2))
+    , m_x{ x }
+    , m_y{ y }
+    {
+    }
+
+    int m_x;
+    int m_y;
+};
+
+class EventObject : public KDFoundation::Object
+{
+public:
+    EventObject(int expectedX, int expectedY)
+    : m_expectedX{ expectedX }
+    , m_expectedY{ expectedY }
+    {
+    }
+
+    bool userEventDelivered() const { return m_userEventDelivered; }
+
+protected:
+    void userEvent(KDFoundation::Event *ev) override
+    {
+        if (ev->type() == static_cast<KDFoundation::Event::Type>(static_cast<uint16_t>(KDFoundation::Event::Type::UserType) + 2)) {
+            auto e = static_cast<PayloadEvent *>(ev);
+            if (e->m_x == m_expectedX && e->m_y == m_expectedY) {
+                e->setAccepted(true);
+                m_userEventDelivered = true;
+            }
+        }
+    }
+
+private:
+    int m_expectedX;
+    int m_expectedY;
+    bool m_userEventDelivered = false;
+};
+
+class RecursiveEventPosterObject : public KDFoundation::Object
+{
+public:
+    RecursiveEventPosterObject(std::thread::id expectedThreadId = {}, size_t maxEvents = 1000)
+    : m_expectedThreadId(expectedThreadId)
+    , m_maxEvents{ maxEvents }
+    {
+    }
+
+    size_t eventsProcessed() const { return m_eventsProcessed; }
+
+    void requestUpdate()
+    {
+        KDFoundation::EventLoop::instance()->postEvent(this, std::make_unique<KDFoundation::UpdateEvent>());
+    }
+
+protected:
+    void event(KDFoundation::EventReceiver *target, KDFoundation::Event *ev) override
+    {
+        if (target == this && ev->type() == KDFoundation::Event::Type::Update) {
+            if (m_expectedThreadId != std::thread::id{}) {
+                CHECK(std::this_thread::get_id() == m_expectedThreadId);
+            }
+            ++m_eventsProcessed;
+            ev->setAccepted(true);
+            if (m_eventsProcessed != m_maxEvents) {
+                requestUpdate();
+            } else {
+                KDFoundation::EventLoop::instance()->quit();
+            }
+        }
+
+        KDFoundation::Object::event(target, ev);
+    }
+
+private:
+    std::thread::id m_expectedThreadId;
+    size_t m_maxEvents{ 0 };
+    size_t m_eventsProcessed{ 0 };
+};

--- a/tests/auto/foundation/core_application/tst_core_application.cpp
+++ b/tests/auto/foundation/core_application/tst_core_application.cpp
@@ -9,6 +9,8 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#include "../common/event_mockups.h"
+
 #include <KDFoundation/config.h>
 #include <KDFoundation/core_application.h>
 #include <KDFoundation/timer.h>
@@ -34,78 +36,6 @@ static_assert(!std::is_copy_assignable<CoreApplication>{});
 static_assert(!std::is_move_constructible<CoreApplication>{});
 static_assert(!std::is_move_assignable<CoreApplication>{});
 
-class PayloadEvent : public Event
-{
-public:
-    PayloadEvent(int x, int y)
-        : Event(static_cast<Event::Type>(static_cast<uint16_t>(Event::Type::UserType) + 2))
-        , m_x{ x }
-        , m_y{ y }
-    {
-    }
-
-    int m_x;
-    int m_y;
-};
-
-class EventObject : public Object
-{
-public:
-    EventObject(int expectedX, int expectedY)
-        : m_expectedX{ expectedX }
-        , m_expectedY{ expectedY }
-    {
-    }
-
-    bool userEventDelivered() const { return m_userEventDelivered; }
-
-protected:
-    void userEvent(Event *ev) override
-    {
-        if (ev->type() == static_cast<Event::Type>(static_cast<uint16_t>(Event::Type::UserType) + 2)) {
-            auto e = static_cast<PayloadEvent *>(ev);
-            if (e->m_x == m_expectedX && e->m_y == m_expectedY) {
-                e->setAccepted(true);
-                m_userEventDelivered = true;
-            }
-        }
-    }
-
-private:
-    int m_expectedX;
-    int m_expectedY;
-    bool m_userEventDelivered = false;
-};
-
-class RecursiveEventPosterObject : public Object
-{
-public:
-    RecursiveEventPosterObject()
-    {
-    }
-
-    size_t eventsProcessed() const { return m_eventsProcessed; }
-
-    void requestUpdate()
-    {
-        CoreApplication::instance()->postEvent(this, std::make_unique<UpdateEvent>());
-    }
-
-protected:
-    void event(EventReceiver *target, Event *ev) override
-    {
-        if (target == this && ev->type() == Event::Type::Update) {
-            ++m_eventsProcessed;
-            ev->setAccepted(true);
-            requestUpdate();
-        }
-
-        Object::event(target, ev);
-    }
-
-private:
-    size_t m_eventsProcessed{ 0 };
-};
 
 TEST_CASE("Creation")
 {
@@ -275,6 +205,57 @@ TEST_CASE("Timer handling" * doctest::timeout(120))
         app.processEvents(adjustTimeout(100));
         REQUIRE(fired == true);
     }
+
+
+    SUBCASE("Timer fires on correct thread")
+    {
+        using namespace std::literals::chrono_literals;
+
+
+        CoreApplication app;
+
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+        int timeoutCount = 0;
+
+        auto runWorkerThread = [&mutex, &cond, &ready, &app, &timeoutCount]() {
+            SPDLOG_INFO("Launched worker thread");
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+
+            EventLoop loop;
+
+            auto workerThreadId = std::this_thread::get_id();
+            Timer timer;
+            timer.interval = adjustTimeout(100ms);
+            timer.running = true;
+
+            std::ignore = timer.timeout.connect([&]() {
+                CHECK(std::this_thread::get_id() == workerThreadId);
+                timeoutCount++;
+                timer.running = false;
+                loop.quit();
+                app.quit();
+            });
+
+            loop.exec();
+        };
+        std::thread t1(runWorkerThread);
+
+        {
+            SPDLOG_INFO("Waking up worker thread");
+            const std::unique_lock lock(mutex);
+            ready = true;
+            cond.notify_all();
+        }
+
+        // std::this_thread::sleep_for(5000ms);
+        app.exec();
+        REQUIRE(timeoutCount == 1);
+
+        t1.join();
+    }
 }
 
 TEST_CASE("Main event loop")
@@ -317,6 +298,202 @@ TEST_CASE("Main event loop")
         REQUIRE(elapsedTime < 1000);
 
         t1.join();
+    }
+
+
+    SUBCASE("Main event loop shall not outlive CoreApplication")
+    {
+        class EventObject : public KDFoundation::Object
+        {
+        public:
+            void event(EventReceiver *, Event *ev) override
+            {
+                if (ev->type() == KDFoundation::Event::Type::Update) {
+                    ev->setAccepted(true);
+                    ++eventsProcessed;
+                    REQUIRE(CoreApplication::instance());
+
+                    auto ev = std::make_unique<KDFoundation::UpdateEvent>();
+                    CoreApplication::instance()->postEvent(this, std::move(ev));
+                }
+            }
+
+            size_t eventsProcessed = 0;
+        };
+        std::unique_ptr<EventObject> obj;
+
+        {
+            CoreApplication app;
+
+            obj = std::make_unique<EventObject>();
+            auto ev = std::make_unique<KDFoundation::UpdateEvent>();
+            app.postEvent(obj.get(), std::move(ev));
+        }
+
+        CHECK(obj->eventsProcessed == 1);
+    }
+}
+
+TEST_CASE("Worker thread event loop")
+{
+    spdlog::set_level(spdlog::level::debug);
+
+    SUBCASE("Can create and execute an event loop in a worker thread")
+    {
+        CoreApplication app;
+
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+
+        auto runWorkerThread = [&mutex, &cond, &ready, &app]() {
+            SPDLOG_INFO("Launched worker thread");
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+
+            EventLoop loop;
+
+            auto ev = std::make_unique<PayloadEvent>(5, 6);
+            auto obj = app.createChild<EventObject>(5, 6);
+            loop.postEvent(obj, std::move(ev));
+            REQUIRE(loop.eventQueueSize() == 1);
+            REQUIRE(app.eventQueueSize() == 0);
+
+            loop.processEvents();
+            REQUIRE(obj->userEventDelivered() == true);
+            REQUIRE(app.eventQueueSize() == 0);
+
+            loop.quit();
+            const auto startTime = std::chrono::steady_clock::now();
+            SPDLOG_INFO("Worker thread entering event loop");
+            loop.exec();
+            const auto endTime = std::chrono::steady_clock::now();
+
+            auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+            SPDLOG_INFO("elapsedTime = {}", elapsedTime);
+            REQUIRE(elapsedTime < 1000);
+        };
+        std::thread t1(runWorkerThread);
+
+        {
+            SPDLOG_INFO("Waking up worker thread");
+            const std::unique_lock lock(mutex);
+            ready = true;
+            cond.notify_all();
+        }
+
+        t1.join();
+    }
+
+
+    SUBCASE("Can run main loop and worker thread event loop simultaneously")
+    {
+        CoreApplication app;
+
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+
+        auto runWorkerThread = [&mutex, &cond, &ready, &app]() {
+            SPDLOG_INFO("Launched worker thread");
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+
+            EventLoop loop;
+
+            auto obj = std::make_unique<RecursiveEventPosterObject>(std::this_thread::get_id(), 16);
+            obj->requestUpdate();
+
+            // Check that event is posted on current thread's event loop
+            loop.processEvents();
+            CHECK(obj->eventsProcessed() == 1);
+
+            const auto startTime = std::chrono::steady_clock::now();
+            SPDLOG_INFO("Worker thread entering event loop");
+            loop.exec();
+            const auto endTime = std::chrono::steady_clock::now();
+
+            auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+            SPDLOG_INFO("Worker thread: elapsedTime = {}", elapsedTime);
+            REQUIRE(elapsedTime < 1000);
+
+            CHECK(obj->eventsProcessed() == 16);
+
+            SPDLOG_INFO("Worker thread requesting the app to quit");
+            app.quit();
+        };
+        std::thread t1(runWorkerThread);
+
+        {
+            SPDLOG_INFO("Waking up helper thread");
+            const std::unique_lock lock(mutex);
+            ready = true;
+            cond.notify_all();
+        }
+
+
+        auto obj = std::make_unique<RecursiveEventPosterObject>(std::this_thread::get_id(), 5);
+        obj->requestUpdate();
+
+        const auto startTime = std::chrono::steady_clock::now();
+        SPDLOG_INFO("Main thread entering event loop");
+        app.exec();
+        const auto endTime = std::chrono::steady_clock::now();
+
+        auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+        SPDLOG_INFO("Main thread: elapsedTime = {}", elapsedTime);
+        REQUIRE(elapsedTime < 1000);
+
+        CHECK(obj->eventsProcessed() == 5);
+
+        t1.join();
+    }
+
+
+    SUBCASE("Worker thread's event loop can outlive CoreApplication")
+    {
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+
+        std::thread worker_thread;
+
+        {
+            CoreApplication app;
+
+            auto runWorkerThread = [&mutex, &cond, &ready]() {
+                SPDLOG_INFO("Launched worker thread");
+
+                EventLoop loop;
+
+                auto obj = std::make_unique<RecursiveEventPosterObject>(std::this_thread::get_id(), 128);
+                obj->requestUpdate();
+
+                {
+                    SPDLOG_INFO("Waking up main thread");
+                    const std::unique_lock lock(mutex);
+                    ready = true;
+                    cond.notify_all();
+                }
+
+                const auto startTime = std::chrono::steady_clock::now();
+                SPDLOG_INFO("Worker thread entering event loop");
+                loop.exec();
+                const auto endTime = std::chrono::steady_clock::now();
+
+                auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+                SPDLOG_INFO("Worker thread: elapsedTime = {}", elapsedTime);
+                REQUIRE(elapsedTime < 1000);
+
+                CHECK(obj->eventsProcessed() == 128);
+            };
+            worker_thread = std::thread(runWorkerThread);
+
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+        }
+
+        worker_thread.join();
     }
 }
 

--- a/tests/auto/foundation/object/tst_object.cpp
+++ b/tests/auto/foundation/object/tst_object.cpp
@@ -408,6 +408,27 @@ TEST_CASE("Deferred object destruction")
         REQUIRE(objectDestroyedSpy.count() == 1);
         REQUIRE(std::get<0>(objectDestroyedSpy.args()) == obj);
     }
+
+    SUBCASE("Can call deleteLater from worker thread")
+    {
+        CoreApplication app;
+
+        auto runWorkerThread = []() {
+            EventLoop loop;
+            auto obj = new Object();
+
+            SignalSpy<Object *> objectDestroyedSpy(obj->destroyed);
+            obj->deleteLater();
+
+            REQUIRE(objectDestroyedSpy.count() == 0);
+            loop.processEvents();
+            REQUIRE(objectDestroyedSpy.count() == 1);
+            REQUIRE(std::get<0>(objectDestroyedSpy.args()) == obj);
+        };
+        std::thread t1(runWorkerThread);
+
+        t1.join();
+    }
 }
 
 TEST_CASE("Event delivery")
@@ -428,5 +449,38 @@ TEST_CASE("Event delivery")
         object->event(object.get(), ev.get());
 
         REQUIRE(object->m_timerEventDelivered == true);
+    }
+
+
+    SUBCASE("Object destruction cleans up event queue")
+    {
+        CoreApplication app;
+
+        class EventObject : public KDFoundation::Object
+        {
+        public:
+            void event(EventReceiver *, Event *ev) override
+            {
+                if (ev->type() == KDFoundation::Event::Type::Update) {
+                    REQUIRE(false);
+                }
+            }
+        };
+
+        auto runWorkerThread = [&app]() {
+            EventLoop loop;
+
+            auto obj = std::make_unique<EventObject>();
+            app.postEvent(obj.get(), std::make_unique<KDFoundation::UpdateEvent>());
+            loop.postEvent(obj.get(), std::make_unique<KDFoundation::UpdateEvent>());
+
+            obj.reset();
+
+            loop.processEvents();
+        };
+        std::thread t1(runWorkerThread);
+
+
+        t1.join();
     }
 }

--- a/tests/auto/gui/CMakeLists.txt
+++ b/tests/auto/gui/CMakeLists.txt
@@ -12,6 +12,7 @@ project(KDGui-Tests)
 
 include_directories(../KDFoundation/common)
 
+add_subdirectory(gui_application)
 add_subdirectory(position)
 add_subdirectory(window)
 

--- a/tests/auto/gui/gui_application/CMakeLists.txt
+++ b/tests/auto/gui/gui_application/CMakeLists.txt
@@ -1,0 +1,27 @@
+# This file is part of KDUtils.
+#
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# Author: Paul Lemire <paul.lemire@kdab.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# Contact KDAB at <info@kdab.com> for commercial licensing options.
+#
+
+project(
+    test-gui-gui-application
+    VERSION 0.1
+    LANGUAGES CXX
+)
+
+add_executable(
+    ${PROJECT_NAME}
+    tst_gui_application.cpp
+)
+
+target_link_libraries(
+    ${PROJECT_NAME} KDGui doctest::doctest
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>)
+set_tests_properties(${PROJECT_NAME} PROPERTIES LABELS "Gui")

--- a/tests/auto/gui/gui_application/tst_gui_application.cpp
+++ b/tests/auto/gui/gui_application/tst_gui_application.cpp
@@ -1,0 +1,303 @@
+/*
+ *  This file is part of KDUtils.
+ *
+ *  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+ *  Author: Paul Lemire <paul.lemire@kdab.com>
+ *  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ *  Contact KDAB at <info@kdab.com> for commercial licensing options.
+ */
+
+#include "../../foundation/common/event_mockups.h"
+
+#include <KDFoundation/event_loop.h>
+#include <KDFoundation/timer.h>
+#include <KDGui/gui_application.h>
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest.h>
+
+using namespace KDFoundation;
+using namespace KDGui;
+
+TEST_CASE("Creation")
+{
+    SUBCASE("default construction")
+    {
+        const GuiApplication app;
+        REQUIRE(GuiApplication::instance() != nullptr);
+    }
+
+    SUBCASE("Can access one and only instance via instance function")
+    {
+        REQUIRE(GuiApplication::instance() == nullptr);
+        auto *app = new GuiApplication;
+        REQUIRE(GuiApplication::instance() == app);
+        delete app;
+        REQUIRE(GuiApplication::instance() == nullptr);
+    }
+}
+
+TEST_CASE("Timer handling" * doctest::timeout(120))
+{
+    SUBCASE("Timer fires on correct thread")
+    {
+        using namespace std::literals::chrono_literals;
+
+
+        CoreApplication app;
+
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+        int timeoutCount = 0;
+
+        auto runWorkerThread = [&mutex, &cond, &ready, &app, &timeoutCount]() {
+            SPDLOG_INFO("Launched worker thread");
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+
+            EventLoop loop;
+
+            auto workerThreadId = std::this_thread::get_id();
+            Timer timer;
+            timer.interval = 100ms;
+            timer.running = true;
+
+            std::ignore = timer.timeout.connect([&]() {
+                CHECK(std::this_thread::get_id() == workerThreadId);
+                timeoutCount++;
+                timer.running = false;
+                loop.quit();
+                app.quit();
+            });
+
+            loop.exec();
+        };
+        std::thread t1(runWorkerThread);
+
+        {
+            SPDLOG_INFO("Waking up worker thread");
+            const std::unique_lock lock(mutex);
+            ready = true;
+            cond.notify_all();
+        }
+
+        // std::this_thread::sleep_for(5000ms);
+        app.exec();
+        REQUIRE(timeoutCount == 1);
+
+        t1.join();
+    }
+}
+
+TEST_CASE("Main event loop")
+{
+    spdlog::set_level(spdlog::level::debug);
+
+    SUBCASE("can enter the main event loop and quit from another thread")
+    {
+        GuiApplication app;
+
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+        auto quitTheApp = [&mutex, &cond, &ready, &app]() {
+            SPDLOG_INFO("Launched worker thread");
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+            SPDLOG_INFO("Worker thread going to sleep before quitting the app event loop");
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            SPDLOG_INFO("Worker thread requesting the app to quit");
+            app.quit();
+        };
+        std::thread t1(quitTheApp);
+
+        {
+            SPDLOG_INFO("Waking up helper thread");
+            const std::unique_lock lock(mutex);
+            ready = true;
+            cond.notify_all();
+        }
+
+        const auto startTime = std::chrono::steady_clock::now();
+        SPDLOG_INFO("Main thread entering event loop");
+        app.exec();
+        const auto endTime = std::chrono::steady_clock::now();
+
+        auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+        SPDLOG_INFO("elapsedTime = {}", elapsedTime);
+        REQUIRE(elapsedTime < 1000);
+
+        t1.join();
+    }
+}
+
+TEST_CASE("Worker thread event loop")
+{
+    spdlog::set_level(spdlog::level::debug);
+
+    SUBCASE("Can create and execute an event loop in a worker thread")
+    {
+        GuiApplication app;
+
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+
+        auto runWorkerThread = [&mutex, &cond, &ready, &app]() {
+            SPDLOG_INFO("Launched worker thread");
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+
+            EventLoop loop;
+
+            auto ev = std::make_unique<PayloadEvent>(5, 6);
+            auto obj = app.createChild<EventObject>(5, 6);
+            loop.postEvent(obj, std::move(ev));
+            REQUIRE(loop.eventQueueSize() == 1);
+            REQUIRE(app.eventQueueSize() == 0);
+
+            loop.processEvents();
+            REQUIRE(obj->userEventDelivered() == true);
+            REQUIRE(app.eventQueueSize() == 0);
+
+            loop.quit();
+            const auto startTime = std::chrono::steady_clock::now();
+            SPDLOG_INFO("Worker thread entering event loop");
+            loop.exec();
+            const auto endTime = std::chrono::steady_clock::now();
+
+            auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+            SPDLOG_INFO("elapsedTime = {}", elapsedTime);
+            REQUIRE(elapsedTime < 1000);
+        };
+        std::thread t1(runWorkerThread);
+
+        {
+            SPDLOG_INFO("Waking up worker thread");
+            const std::unique_lock lock(mutex);
+            ready = true;
+            cond.notify_all();
+        }
+
+        t1.join();
+    }
+
+
+    SUBCASE("Can run main loop and worker thread event loop simultaneously")
+    {
+        GuiApplication app;
+
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+
+        auto runWorkerThread = [&mutex, &cond, &ready, &app]() {
+            SPDLOG_INFO("Launched worker thread");
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+
+            EventLoop loop;
+
+            auto obj = std::make_unique<RecursiveEventPosterObject>(std::this_thread::get_id(), 16);
+            obj->requestUpdate();
+
+            // Check that event is posted on current thread's event loop
+            loop.processEvents();
+            CHECK(obj->eventsProcessed() == 1);
+
+            const auto startTime = std::chrono::steady_clock::now();
+            SPDLOG_INFO("Worker thread entering event loop");
+            loop.exec();
+            const auto endTime = std::chrono::steady_clock::now();
+
+            auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+            SPDLOG_INFO("Worker thread: elapsedTime = {}", elapsedTime);
+            REQUIRE(elapsedTime < 1000);
+
+            CHECK(obj->eventsProcessed() == 16);
+
+            SPDLOG_INFO("Worker thread requesting the app to quit");
+            app.quit();
+        };
+        std::thread t1(runWorkerThread);
+
+        {
+            SPDLOG_INFO("Waking up helper thread");
+            const std::unique_lock lock(mutex);
+            ready = true;
+            cond.notify_all();
+        }
+
+
+        auto obj = std::make_unique<RecursiveEventPosterObject>(std::this_thread::get_id(), 5);
+        obj->requestUpdate();
+
+        const auto startTime = std::chrono::steady_clock::now();
+        SPDLOG_INFO("Main thread entering event loop");
+        app.exec();
+        const auto endTime = std::chrono::steady_clock::now();
+
+        auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+        SPDLOG_INFO("Main thread: elapsedTime = {}", elapsedTime);
+        REQUIRE(elapsedTime < 1000);
+
+        CHECK(obj->eventsProcessed() == 5);
+
+        t1.join();
+    }
+
+    SUBCASE("Worker thread's event loop can outlive GuiApplication")
+    {
+        std::mutex mutex;
+        std::condition_variable cond;
+        bool ready = false;
+
+        std::thread worker_thread;
+
+        {
+            GuiApplication app;
+
+            auto runWorkerThread = [&mutex, &cond, &ready]() {
+                SPDLOG_INFO("Launched worker thread");
+
+                EventLoop loop;
+
+                auto obj = std::make_unique<RecursiveEventPosterObject>(std::this_thread::get_id(), 128);
+                obj->requestUpdate();
+
+                {
+                    SPDLOG_INFO("Waking up main thread");
+                    const std::unique_lock lock(mutex);
+                    ready = true;
+                    cond.notify_all();
+                }
+
+                const auto startTime = std::chrono::steady_clock::now();
+                SPDLOG_INFO("Worker thread entering event loop");
+                loop.exec();
+                const auto endTime = std::chrono::steady_clock::now();
+
+                auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+                SPDLOG_INFO("Worker thread: elapsedTime = {}", elapsedTime);
+                REQUIRE(elapsedTime < 1000);
+
+                CHECK(obj->eventsProcessed() == 128);
+            };
+            worker_thread = std::thread(runWorkerThread);
+
+            std::unique_lock lock(mutex);
+            cond.wait(lock, [&ready] { return ready; });
+        }
+
+        worker_thread.join();
+    }
+}


### PR DESCRIPTION
Refactors the eventloop functionality of CoreApplication into its own EventLoop class. This EventLoop class can be used to execute event loops on worker threads.

Renames CoreApplication::eventLoop() to
CoreApplication::platformEventLoop() and make
CoreApplication::eventLoop() return a pointer to the new EventLoop type.