### PR TITLE
Fix build on Android

### DIFF
--- a/src/KDFoundation/core_application.cpp
+++ b/src/KDFoundation/core_application.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <cassert>
+#include <stdexcept>
 
 using namespace KDFoundation;
 
@@ -37,6 +38,8 @@ std::unique_ptr<AbstractPlatformIntegration> createPlatformIntegration()
     return std::make_unique<Win32PlatformIntegration>();
 #elif defined(PLATFORM_MACOS)
     return std::make_unique<MacOSPlatformIntegration>();
+#elif defined(PLATFORM_ANDROID)
+    throw std::runtime_error("Direct creation of CoreApplication not supported on android. Use KDGui::GuiApplication");
 #else
     static_assert(false, "No valid platform integration could be found.");
 #endif


### PR DESCRIPTION
Platform integration choosing in CoreApplication won't be ever called for Android (unless someone tries to instantiate non-gui application) but we can't static_assert since we won't compile.

Now, an exception is thrown when the user attempts to create CoreApplication on Android.