### PR TITLE
Bump clan-format and fix config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,6 +19,7 @@ AlwaysBreakTemplateDeclarations: true
 BreakBeforeBinaryOperators: None
 
 SpaceBeforeCpp11BracedList: false
+SpaceInEmptyBraces: Block
 BreakBeforeBraces: Custom
 BraceWrapping:
     AfterClass: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     args: [--allow-multiple-documents]
   - id: check-json
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v21.1.6
+  rev: v22.1.0
   hooks:
   - id: clang-format
 - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
With clang-format 22 the new setting about empty braced initializers caused a lot of formatting churn. Setting SpaceInEmptyBraces=Block gets rid of most of the churn.