### PR TITLE
KDFoundation: add missing glm dependency required by formatters.h

### DIFF
--- a/.github/workflows/build-external.yml
+++ b/.github/workflows/build-external.yml
@@ -38,7 +38,7 @@ jobs:
                                                                 # TODO: remove when not needed anymore
           brew tap KDAB/tap
           brew trust kdab/tap
-          brew install doctest fmt spdlog KDBindings mosquitto
+          brew install doctest fmt spdlog KDBindings mosquitto glm
 
       - name: Configure project
         run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           git clone https://github.com/gabime/spdlog && cd spdlog && cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/opt/android-sdk-linux/ndk/28.0.13004108/prebuilt/linux-x86_64/ && cd build && ninja install
           git clone https://github.com/KDAB/KDBindings && cd KDBindings && cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/opt/android-sdk-linux/ndk/28.0.13004108/prebuilt/linux-x86_64/ && cd build && ninja install
+          git clone https://github.com/g-truc/glm.git && cd glm && cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/opt/android-sdk-linux/ndk/28.0.13004108/prebuilt/linux-x86_64/ && cd build && ninja install
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/dependency-bump.yml
+++ b/.github/workflows/dependency-bump.yml
@@ -14,6 +14,7 @@ on:
           - fmt
           - KDBindings
           - doctest
+          - glm
 
 name: bump dependencies
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ project(
     KDUtils
     DESCRIPTION "A set of C++ helpers and wrappers around the C++ standard library"
     LANGUAGES CXX C
-    VERSION 0.1.13
+    VERSION 0.1.14
     HOMEPAGE_URL "https://github.com/KDAB/KDUtils"
 )
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -14,6 +14,7 @@ message(STATUS "Looking for KDUtils dependencies")
 
 find_package(spdlog REQUIRED)
 find_package(KDBindings REQUIRED)
+find_package(glm CONFIG REQUIRED)
 
 # Following two packages are still acquired via fetchcontent because they aren't
 # available in brew on macOS so the non-vcpkg build would be hard to set up there

--- a/src/KDFoundation/CMakeLists.txt
+++ b/src/KDFoundation/CMakeLists.txt
@@ -99,7 +99,7 @@ add_library(
 
 target_link_libraries(
     KDFoundation
-    PUBLIC KDUtils::KDUtils KDAB::KDBindings
+    PUBLIC KDUtils::KDUtils KDAB::KDBindings glm::glm
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "kdutils",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "description": "KD Utilities Library - Core utilities and helper functions",
     "homepage": "https://github.com/KDAB/kdutils",
     "license": "MIT",
@@ -21,7 +21,8 @@
         {
             "name": "mio",
             "version>=": "2023-03-03"
-        }
+        },
+        "glm"
     ],
     "features": {
         "testing": {


### PR DESCRIPTION
Otherwise formatters (in formatters.h) are only usable if consumers of KDFoundation depend themselves on glm

Bump project version to 0.1.14